### PR TITLE
Typo fix: Psedo -> Pseudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ const styleTag = `<style>${css()}</style>`
 ```
 
 ## Advanced
-**Psedo States**
+**Pseudo States**
 `&:hover`, `&:active`, `&:focus`, `&:disabled` as you would expect e.g.
 
 ```tsx


### PR DESCRIPTION
There was a typo. This fixes the "Pseudo" state.