### PR TITLE
The first argument to style and keyframes can be a "display name".

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const className = style({color: 'red'});
 
 /** Use the class name in a framework of choice */
 //  e.g. React
-const MyButton = 
+const MyButton =
   ({onClick,children})
     => <button className={className} onClick={onClick}>
         {children}
@@ -59,7 +59,7 @@ export class MyComponent {}
 
 ## Server Side
 
-Just get the styles as CSS at any point and render it in a style tag yourself. e.g. 
+Just get the styles as CSS at any point and render it in a style tag yourself. e.g.
 
 ```ts
 /** Import */
@@ -148,7 +148,7 @@ const tallRedClass = typestyle.classes(tallClass, redClass);
 
 /** Even conditionally (any falsy parameters are ignored in the composed class name) */
 const mightBeRed = typestyle.classes(tallClass, hasError && redClass);
-``` 
+```
 
 **Animations**
 Use `keyframes` to define an animation and get the animation name
@@ -163,6 +163,21 @@ const ooooClass = typestyle.style({
   animationDuration: '1s'
 });
 ```
+
+**Display names for Debugging**
+ The first argument to style and keyframes can be a "display name". The display
+ name will be used as the class name prefix in development (process.env.NODE_ENV !== 'production').
+ ```tsx
+ const colorAnimationName = typestyle.keyframes('myAnimation', {
+   from: { color: 'red' },
+   to: { color: 'blue' }
+ })
+
+ const ooooClass = typestyle.style('myClass', {
+   animationName: colorAnimationName,
+   animationDuration: '1s'
+ });
+ ```
 
 **TypeScript Protip: namespace**
 ```tsx

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,20 +48,34 @@ export function reinit() {
 export const css = () => freeStyle.getStyles();
 
 /**
- * Takes CSSProperties and return a generated className you can use on your component
+ * Takes CSSProperties and return a generated className you can use on your component.
+ * The first argument can be a "display name". The display name will be used as
+ * the class name prefix in development (process.env.NODE_ENV !== 'production')
  */
-export function style(...objects: NestedCSSProperties[]) {
-  const object = extend(...objects);
-  const className = freeStyle.registerStyle(object);
+export function style(nameOrObject:(string | NestedCSSProperties), ...objects: NestedCSSProperties[]) {
+  let object = extend(...objects);
+  let displayName: string = null;
+  if (typeof nameOrObject !== "string") {
+    object = extend(nameOrObject, ...objects);
+  }else {
+    displayName = nameOrObject
+  }
+  const className = freeStyle.registerStyle(object, displayName);
   styleUpdated();
   return className;
 }
 
 /**
  * Takes Keyframes and returns a generated animation name
+ * The first argument can be a "display name". The display name will be used as
+ * the class name prefix in development (process.env.NODE_ENV !== 'production')
  */
-export function keyframes(frames: KeyFrames) {
-  const animationName = freeStyle.registerKeyframes(frames);
+export function keyframes(nameOrFrames:(string | KeyFrames), frames: KeyFrames) {
+  const displayName: string = typeof nameOrFrames === "string" ? nameOrFrames : null;
+  const framesToUse: KeyFrames = typeof nameOrFrames !== "string" ? nameOrFrames : frames
+
+  const animationName = freeStyle.registerKeyframes(framesToUse, displayName);
+
   styleUpdated();
   return animationName;
 }


### PR DESCRIPTION
Hi,

i like your lib but i was missing a tiny thing, to set a display name for debugging purposes like free-style does it.
I choose to use the first instead of the last parameter for displayName because it was easier for me to deconstruct the parameters. I'm new to TypeScript and i have no experience how to deal with overloading of functions correctly. I added an example to the Readme.md how to use it.

Hope you like it. 
Cheers Martin

p.s. This is my first or second PullRequest on GitHub, Please be kind to me  ;) 
