### PR TITLE
CSSType, CSS Def Improvements, Example CSS Function Helpers

### DIFF
--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -1,4 +1,63 @@
 /**
+ * an angle; 0' | '0deg' | '0grad' | '0rad' | '0turn' | 'etc.
+ * https://drafts.csswg.org/css-values-3/#angles
+ */
+type CSSAngle = CSSGlobalValues | string | 0 | CSSType<'angle'>;
+
+/**
+ * an length; 0 | '0px' | '0em' etc.
+ * https://drafts.csswg.org/css-values-3/#angles
+ */
+type CSSLength = CSSGlobalValues | string | 0 | CSSType<'length'>;
+
+/**
+ * a percentage; 0 | '0%' etc.
+ * https://drafts.csswg.org/css-values-3/#percentage
+ */
+type CSSPercentage = CSSGlobalValues | string | 0 | CSSType<'percentage'>;
+
+/**
+ * Color can be a named color, transparent, or a color function
+ * https://drafts.csswg.org/css-color-3/#valuea-def-color
+ */
+type CSSColor =
+  CSSGlobalValues  
+  /* color function as a string */  
+  | string
+  | 'transparent'
+  /* basic colors */  
+  | 'aqua' | 'black' | 'blue' | 'fuchsia' | 'gray' | 'green' | 'lime' | 'maroon' | 'navy' | 'olive' | 'purple' | 'red' | 'silver' | 'teal' | 'white' | 'yellow'
+  | CSSType<'color'>;
+
+/**
+ * Starting position for many gradients
+ * https://drafts.csswg.org/css-images-3/#typedef-side-or-corner
+ */
+type CSSSideOrCorner = CSSAngle
+  | 'left' | 'right' | 'top' | 'bottom'
+  | 'to left' | 'to right' | 'to top' | 'to bottom'
+  | 'left top' | 'right top' | 'left bottom' | 'right bottom'
+  | 'top left' | 'top right' | 'bottom left' | 'bottom right'
+  | 'to left top' | 'to right top' | 'to left bottom' | 'to right bottom'
+  | 'to top left' | 'to top right' | 'to bottom left' | 'to bottom right'
+  | CSSType<'side-or-corner'>;  
+
+/**
+ * initial state of an animation.
+ * https://drafts.csswg.org/css-animations/#animation-play-state
+ */
+type CSSAnimationPlayState = CSSGlobalValues | string | 'paused' | 'running' | CSSType<'animation-play-state'>;
+
+/**
+ * Interface for CSS Property Helpers.
+ * Must implement toString and declare the dataType they handle ('color', 'length', etc.)
+ */
+type CSSType<T extends string> = {
+  toString(): string;
+  dataType: T;
+}
+
+/**
  * CSS properties that cascade also support these
  * https://drafts.csswg.org/css-cascade/#defaulting-keywords
  */
@@ -128,7 +187,7 @@ interface CSSProperties {
   /**
    * Sets the background color of an element.
    */
-  backgroundColor?: any;
+  backgroundColor?: CSSColor;
 
   backgroundComposite?: any;
 
@@ -1448,7 +1507,7 @@ interface NestedCSSProperties extends CSSProperties {
   '&:last-child'?: NestedCSSProperties;
 
   /** General purpose */
-  [selector: string]: CSSValueGeneral | NestedCSSProperties;
+  [selector: string]: CSSValueGeneral | CSSType<string> |  NestedCSSProperties;
 }
 
 /**

--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -17,6 +17,18 @@ type CSSLength = CSSGlobalValues | string | 0 | CSSType<'length'>;
 type CSSPercentage = CSSGlobalValues | string | 0 | CSSType<'percentage'>;
 
 /**
+ * a gradient function like linear-gradient
+ * https://drafts.csswg.org/css-images-3/#gradients
+ */
+type CSSGradient = CSSGlobalValues | string | CSSType<'gradient'>;
+
+/**
+ * a value that serves as an image
+ * https://drafts.csswg.org/css-images-3/#typedef-image
+ */
+type CSSImage = CSSGlobalValues | string | CSSGradient;
+
+/**
  * Color can be a named color, transparent, or a color function
  * https://drafts.csswg.org/css-color-3/#valuea-def-color
  */
@@ -52,7 +64,7 @@ type CSSAnimationPlayState = CSSGlobalValues | string | 'paused' | 'running' | C
  * Interface for CSS Property Helpers.
  * Must implement toString and declare the dataType they handle ('color', 'length', etc.)
  */
-type CSSType<T extends string> = {
+type CSSType<T> = {
   toString(): string;
   dataType: T;
 }
@@ -194,7 +206,7 @@ interface CSSProperties {
   /**
    * Applies one or more background images to an element. These can be any valid CSS image, including url() paths to image files or CSS gradients.
    */
-  backgroundImage?: any;
+  backgroundImage?: CSSImage;
 
   /**
    * Specifies what the background-position property is relative to.

--- a/src/tests/cssFunctions.ts
+++ b/src/tests/cssFunctions.ts
@@ -1,0 +1,85 @@
+import { style, css, hsl, hsla, keyframes, linearGradient, repeatingLinearGradient, reinit } from '../index';
+import * as assert from 'assert';
+
+describe("cssFunctions", () => {
+  it("hsl should resolve", () => {
+    const red = hsl(0, '100%', '50%');
+    assert.equal(red, 'hsl(0,100%,50%)');
+  });
+
+  it("style should resolve hsl correctly", () => {
+    reinit();
+    style({
+      backgroundColor: hsl(0, '100%', '50%')
+    })
+    assert.equal(css(), '.f1ri67gz{background-color:hsl(0,100%,50%)}');
+  });
+
+  it("hsla should resolve", () => {
+    const red = hsla(0, '100%', '50%', .1).toString();
+    assert.equal(red, 'hsla(0,100%,50%,0.1)');
+  });
+
+  it("style should resolve hsla correctly", () => {
+    reinit();
+    style({
+      backgroundColor: hsla(0, '100%', '50%', .1)
+    })
+    assert.equal(css(), '.f8x8s41{background-color:hsla(0,100%,50%,0.1)}');
+  });
+
+  it("linear-gradient should resolve", () => {
+    const redBlue = linearGradient('top left', 'red', 'blue').toString();
+    assert.equal(redBlue, 'linear-gradient(top left,red,blue)');
+  });
+
+  it("style should resolve linear-gradient correctly", () => {
+    reinit();
+    style({
+      backgroundImage: linearGradient('top left', 'red', 'blue')
+    })
+    assert.equal(css(), '.fw0gyi9{background-image:linear-gradient(top left,red,blue)}');
+  });
+
+  it("linear-gradient should resolve colors inside of it", () => {
+    const redBlue = linearGradient('top left', hsl(0, '100%', '50%'), ['blue', '40%']).toString();
+    assert.equal(redBlue, 'linear-gradient(top left,hsl(0,100%,50%),blue 40%)');
+  });
+
+  it("style should resolve linear-gradient with colors inside of it", () => {
+    reinit();
+    style({
+      backgroundImage: linearGradient('top left', hsl(0, '100%', '50%'), ['blue', '40%'])
+    })
+    assert.equal(css(), '.f20pb75{background-image:linear-gradient(top left,hsl(0,100%,50%),blue 40%)}');
+  });
+
+  it("style should resolve keyframes with colors inside of it", () => {
+    reinit();
+    const colorAnimation = keyframes({
+      from: {
+        backgroundColor: hsl(250, '50%', '30%')
+      },
+      to: {
+        backgroundColor: hsl(250, '50%', '50%')
+      }
+    });
+    style({
+      animationName: colorAnimation
+    });
+    assert.equal(css(), '@keyframes fic7j4e{from{background-color:hsl(250,50%,30%)}to{background-color:hsl(250,50%,50%)}}.f1f9piqr{animation-name:fic7j4e}');
+  });
+
+  it("repeating-linear-gradient should resolve", () => {
+    const redBlue = repeatingLinearGradient('top left', 'red', 'blue').toString();
+    assert.equal(redBlue, 'repeating-linear-gradient(top left,red,blue)');
+  });
+
+  it("style should resolve repeating-linear-gradient correctly", () => {
+    reinit();
+    style({
+      backgroundImage: repeatingLinearGradient('top left', 'red', 'blue')
+    })
+    assert.equal(css(), '.f9s170r{background-image:repeating-linear-gradient(top left,red,blue)}');
+  });
+})


### PR DESCRIPTION
At its core, this change has a new type named CSSType<> that describes property helpers that target a specific css data type.  It allows the typing system to detect that a correct property helper was used and would allow for richer helper functions.

As an example, the following should result in a type error since hsl returns a CSSType<'color'> object and backgroundImage is expecting a gradient or image:

```typescript
import {style, hsl } from 'typestyle';
style({
    backgroundImage: hsl(250, '50%', '50%')
});
```

The following, however, should compile since linearGradient is of type CSSType<'gradient'> and each color argument can be provided as a string or as CSSType<'color'>:

```typescript
import {style, hsl, linearGradient } from 'typestyle';
style({
    backgroundImage: linearGradient('90deg', hsl(250, '50%', '50%'), [black, '50%'])
});
```

There are four functions that demonstrate how this can be used to allow helper functions to be type checked even if all resolve to strings.  I added a test file named cssFunctions to the tests folder. I also had to change the preprocessing done before freeStyle gets the definitions so it would force the evaluation of these helpers.  

As a side effect, I added more detailed type definitions for color, side-or-corner, angle, length, and percentage as well
