### PR TITLE
Added rule for global styles (body, html, etc.)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,16 @@ export function style(...objects: NestedCSSProperties[]) {
 }
 
 /**
+ * Takes CSSProperties and registers it to a global selector (body, html, etc.)
+ */
+export function rule(selector: string, ...objects: NestedCSSProperties[]): void {
+  const object = extend(...objects);
+  freeStyle.registerRule(selector, object);
+  styleUpdated();
+  return;
+}
+
+/**
  * Takes Keyframes and returns a generated animation name
  */
 export function keyframes(frames: KeyFrames) {

--- a/src/tests/rule.tsx
+++ b/src/tests/rule.tsx
@@ -1,0 +1,11 @@
+import { css, reinit } from '../index';
+import * as assert from 'assert';
+
+describe("test rules", () => {
+  it("it should provide expected output when used as css framework", () => {
+    reinit();
+    require('./rule/layout');
+
+    assert.equal(css(), 'html{height:100%}body{background-color:white;color:blue;font-size:14pt;height:100%;margin:0;padding:0}');
+  });
+});

--- a/src/tests/rule/layout.ts
+++ b/src/tests/rule/layout.ts
@@ -1,0 +1,17 @@
+import { rule } from '../../index';
+import { colors, fonts } from './variables';
+
+// set html styles
+rule('html', {
+    height: '100%'
+});
+
+// set default body styles
+rule('body', {
+    fontSize: fonts.baseSize,
+    margin: 0,
+    padding: 0,
+    height: '100%',
+    backgroundColor: colors.bgColor,
+    color: colors.primary
+});

--- a/src/tests/rule/variables.ts
+++ b/src/tests/rule/variables.ts
@@ -1,0 +1,12 @@
+export const colors = {
+  primary: 'blue',
+  info: 'lightblue',
+  success: 'green',
+  warning: 'orange',
+  danger: 'red',
+  bgColor: 'white'
+};
+
+export const fonts = {
+  baseSize: '14pt'
+};


### PR DESCRIPTION
Added rule() for global rules so typestyle can be used as a drop in replacement for scss or less.