### PR TITLE
Nested Property for nested rules/@rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "@types/node": "^6.0.45",
     "mocha": "^3.1.2",
     "ts-node": "^1.5.2",
-    "typescript": "2.2.0-dev.20161120"
+    "typescript": "2.2.0-dev.20161130"
   }
 }

--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -200,7 +200,8 @@ type CSSUrl = string | CSSType<'url'>;
 /**
  * This interface documents key CSS properties for autocomplete
  */
-interface CSSProperties {
+type CSSPropertyMap = {
+  '-webkit-overflow-scrolling'?: string;
 
   /**
    * Aligns a flex container's lines within the flex container when there is extra space in the cross-axis, similar to how justify-content aligns individual items within the main-axis.
@@ -211,11 +212,15 @@ interface CSSProperties {
    * Sets the default alignment in the cross axis for all of the flex container's items, including anonymous flex items, similarly to how justify-content aligns items along the main axis.
    */
   alignItems?: CSSValue<CSSFlexAlign>;
+  '-ms-alignt-items'?: CSSValue<CSSFlexAlign>;
+  '-webkit-align-items'?: CSSValue<CSSFlexAlign>;
 
   /**
    * Allows the default alignment to be overridden for individual flex items.
    */
   alignSelf?: CSSValue<'auto' | CSSFlexAlign>;
+  '-webkit-align-self'?: CSSValue<'auto' | CSSFlexAlign>;
+  '-ms-flex-item-align'?: string;
 
   /**
    * This property allows precise alignment of elements, such as graphics, that do not have a baseline-table or lack the desired baseline in their baseline-table. With the alignment-adjust property, the position of the baseline identified by the alignment-baseline can be explicitly determined. It also determines precisely the alignment point for each glyph within a textual element.
@@ -529,6 +534,13 @@ interface CSSProperties {
   boxFlex?: number;
 
   /**
+   * box sizing
+   */
+  boxSizing?: string;
+  '-moz-box-sizing'?: string;
+  '-webkit-box-sizing'?: string;
+
+  /**
    * Deprecated.
    */
   boxFlexGroup?: number;
@@ -674,12 +686,16 @@ interface CSSProperties {
    * Shorthand for `flex-grow`, `flex-shrink`, and `flex-basis`.
    */
   flex?: number | string;
+  '-webkit-flex'?: number | string;
+  '-ms-flex'?: number | string;
 
   /**
    * Obsolete, do not use. This property has been renamed to align-items.
    * Specifies the alignment (perpendicular to the layout axis defined by the flex-direction property) of child elements of the object.
    */
   flexAlign?: any;
+  '-ms-flex-align'?: any;
+  '-webkit-flex-align'?: any;
 
   /**
    * The flex-basis CSS property describes the initial main size of the flex item before any free space is distributed according to the flex factors described in the flex property (flex-grow and flex-shrink).
@@ -690,6 +706,8 @@ interface CSSProperties {
    * The flex-direction CSS property describes how flex items are placed in the flex container, by setting the direction of the flex container's main axis.
    */
   flexDirection?: any;
+  '-ms-flex-direction'?: any;
+  '-webkit-flex-direction'?: any;
 
   /**
    * The flex-flow CSS property defines the flex container's main and cross axis. It is a shorthand property for the flex-direction and flex-wrap properties.
@@ -700,6 +718,8 @@ interface CSSProperties {
    * Specifies the flex grow factor of a flex item.
    */
   flexGrow?: number;
+  '-ms-flex-grow'?: number;
+  '-webkit-flex-grow'?: number;
 
   /**
    * Do not use. This property has been renamed to align-self
@@ -713,6 +733,14 @@ interface CSSProperties {
    */
   flexLinePack?: any;
 
+  flexPositive?: any;
+  '-ms-flex-positive'?: any;
+  '-webkit-flex-positive'?: any;
+
+  flexNegative?: any;
+  '-ms-flex-negative'?: any;
+  '-webkit-flex-negative'?: any;
+
   /**
    * Gets or sets a value that specifies the ordinal group that a flexbox element belongs to. This ordinal value identifies the display order for the group.
    */
@@ -722,6 +750,12 @@ interface CSSProperties {
    * Specifies the flex shrink factor of a flex item.
    */
   flexShrink?: number;
+  '-ms-flex-shrink'?: number;
+  '-webkit-flex-shrink'?: number;
+
+  flexWrap?: any;
+  '-ms-flex-wrap'?: any;
+  '-webkit-flex-wrap'?: any;
 
   /**
    * Elements which have the style float are floated horizontally. These elements can move as far to the left or right of the containing element. All elements after the floating element will flow around it, but elements before the floating element are not impacted. If several floating elements are placed after each other, they will float next to each other as long as there is room.
@@ -873,6 +907,8 @@ interface CSSProperties {
    * along the main-axis of their container.
    */
   justifyContent?: "flex-start" | "flex-end" | "center" | "space-between" | "space-around";
+  '-webkit-justify-content'?: "flex-start" | "flex-end" | "center" | "space-between" | "space-around";
+  '-ms-flex-pack'?: string;
 
   layoutGrid?: any;
 
@@ -1606,36 +1642,49 @@ interface CSSProperties {
    * Sets the initial zoom factor of a document defined by @viewport.
    */
   zoom?: "auto" | number;
-
-  [propertyName: string]: any;
 }
 
-/** Provides additional autocomplete for pseudo states + nesting */
-interface NestedCSSProperties extends CSSProperties {
+type NestedCSSProperties = {
+  selector?: string;
+  nested?: NestedCSSProperties | FontFace;
+}
+
+type NestedCSSSelectors = {
   /** States */
-  '&:hover'?: NestedCSSProperties;
-  '&:active'?: NestedCSSProperties;
-  '&:disabled'?: NestedCSSProperties;
-  '&:focus'?: NestedCSSProperties;
+  '&:hover'?: CSSProperties;
+  '&:active'?: CSSProperties;
+  '&:disabled'?: CSSProperties;
+  '&:focus'?: CSSProperties;
 
   /** Children */
-  '&>*'?: NestedCSSProperties;
-  '&:first-child'?: NestedCSSProperties;
-  '&:last-child'?: NestedCSSProperties;
+  '&>*'?: CSSProperties;
+  '&:first-child'?: CSSProperties;
+  '&:last-child'?: CSSProperties;
 
   /**
    * Mobile first media query example
    * e.g. style({ mobile, '@media' : notMobile });
    **/
-  '@media screen and (min-width: 700px)'?: NestedCSSProperties;
+  '@media screen and (min-width: 700px)'?: CSSProperties;
   /**
    * Desktop first media query example
    * e.g. style({ desktop, '@media' : notDesktop });
    **/
-  '@media screen and (max-width: 700px)'?: NestedCSSProperties;
+  '@media screen and (max-width: 700px)'?: CSSProperties;
+  '@font-face'?: FontFace;
+  [selector: string]: CSSProperties | FontFace | undefined;
+};
 
-  /** General purpose */
-  [selector: string]: CSSValueGeneral | CSSType<string> |  NestedCSSProperties | undefined;
+type CSSProperties = CSSPropertyMap & NestedCSSProperties;
+
+type FontFace = {
+  fontFamily?: string;
+  src?: string;
+  unicodeRange?: any;
+  fontVariant?: 'common-ligatures' | 'small-caps' | CSSGlobalValues;
+  fontFeatureSettings?: string;
+  fontWeight?: 'normal' | 'bold' | 'bolder' | 'lighter' | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | CSSGlobalValues;
+  fontSize?: 'normal' | 'italic' | 'oblique' | CSSGlobalValues;
 }
 
 /**
@@ -1645,5 +1694,5 @@ interface KeyFrames {
   [
   /** stuff like `from`, `to` or `10%` etc*/
   key: string
-  ]: NestedCSSProperties;
+  ]: CSSPropertyMap;
 }

--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -1645,6 +1645,28 @@ type CSSPropertyMap = {
 }
 
 type NestedCSSProperties = {
+  nested?: NestedCSSSelectors;
+}
+
+type FontFace = {
+  fontFamily?: string;
+  src?: string;
+  unicodeRange?: any;
+  fontVariant?: 'common-ligatures' | 'small-caps' | CSSGlobalValues;
+  fontFeatureSettings?: string;
+  fontWeight?: 'normal' | 'bold' | 'bolder' | 'lighter' | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | CSSGlobalValues;
+  fontSize?: 'normal' | 'italic' | 'oblique' | CSSGlobalValues;
+}
+
+type MediaQuery = {
+  type?: 'screen' | 'print' | 'all';
+  orientation?: 'landscape' | 'portrait';
+  minWidth?: number;
+  maxWidth?: number;
+}
+
+type NestedCSSSelectors = {
+  /** State selector */
   '&:active'?: CSSProperties;
   '&:any'?: CSSProperties;
   '&:checked'?: CSSProperties;
@@ -1678,40 +1700,22 @@ type NestedCSSProperties = {
   '&:target'?: CSSProperties;
   '&:valid'?: CSSProperties;
   '&:visited'?: CSSProperties;
-  nested?: NestedCSSSelectors;
-}
 
-type FontFace = {
-  fontFamily?: string;
-  src?: string;
-  unicodeRange?: any;
-  fontVariant?: 'common-ligatures' | 'small-caps' | CSSGlobalValues;
-  fontFeatureSettings?: string;
-  fontWeight?: 'normal' | 'bold' | 'bolder' | 'lighter' | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | CSSGlobalValues;
-  fontSize?: 'normal' | 'italic' | 'oblique' | CSSGlobalValues;
-}
-
-type MediaQuery = {
-  type?: 'screen' | 'print' | 'all';
-  orientation?: 'landscape' | 'portrait';
-  minWidth?: number;
-  maxWidth?: number;
-}
-
-type NestedCSSSelectors = {
   /** Children */
   '&>*'?: CSSProperties;
 
   /**
    * Mobile first media query example
-   * e.g. style({ mobile, '@media' : notMobile });
    **/
   '@media screen and (min-width: 700px)'?: CSSProperties;
   /**
    * Desktop first media query example
-   * e.g. style({ desktop, '@media' : notDesktop });
    **/
   '@media screen and (max-width: 700px)'?: CSSProperties;
+
+  /**
+   * Also cater for any other nested query you want
+   */
   [selector: string]: CSSProperties | undefined;
 };
 

--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -1727,5 +1727,5 @@ interface KeyFrames {
   [
   /** stuff like `from`, `to` or `10%` etc*/
   key: string
-  ]: NestedCSSProperties;
+  ]: CSSProperties;
 }

--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -1645,21 +1645,62 @@ type CSSPropertyMap = {
 }
 
 type NestedCSSProperties = {
-  selector?: string;
-  nested?: NestedCSSProperties | FontFace;
+  '&:active'?: CSSProperties;
+  '&:any'?: CSSProperties;
+  '&:checked'?: CSSProperties;
+  '&:default'?: CSSProperties;
+  '&:disabled'?: CSSProperties;
+  '&:empty'?: CSSProperties;
+  '&:enabled'?: CSSProperties;
+  '&:first'?: CSSProperties;
+  '&:first-child'?: CSSProperties;
+  '&:first-of-type'?: CSSProperties;
+  '&:fullscreen'?: CSSProperties;
+  '&:focus'?: CSSProperties;
+  '&:hover'?: CSSProperties;
+  '&:indeterminate'?: CSSProperties;
+  '&:in-range'?: CSSProperties;
+  '&:invalid'?: CSSProperties;
+  '&:last-child'?: CSSProperties;
+  '&:last-of-type'?: CSSProperties;
+  '&:left'?: CSSProperties;
+  '&:link'?: CSSProperties;
+  '&:only-child'?: CSSProperties;
+  '&:only-of-type'?: CSSProperties;
+  '&:optional'?: CSSProperties;
+  '&:out-of-range'?: CSSProperties;
+  '&:read-only'?: CSSProperties;
+  '&:read-write'?: CSSProperties;
+  '&:required'?: CSSProperties;
+  '&:right'?: CSSProperties;
+  '&:root'?: CSSProperties;
+  '&:scope'?: CSSProperties;
+  '&:target'?: CSSProperties;
+  '&:valid'?: CSSProperties;
+  '&:visited'?: CSSProperties;
+  nested?: NestedCSSSelectors;
+}
+
+type FontFace = {
+  fontFamily?: string;
+  src?: string;
+  unicodeRange?: any;
+  fontVariant?: 'common-ligatures' | 'small-caps' | CSSGlobalValues;
+  fontFeatureSettings?: string;
+  fontWeight?: 'normal' | 'bold' | 'bolder' | 'lighter' | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | CSSGlobalValues;
+  fontSize?: 'normal' | 'italic' | 'oblique' | CSSGlobalValues;
+}
+
+type MediaQuery = {
+  type?: 'screen' | 'print' | 'all';
+  orientation?: 'landscape' | 'portrait';
+  minWidth?: number;
+  maxWidth?: number;
 }
 
 type NestedCSSSelectors = {
-  /** States */
-  '&:hover'?: CSSProperties;
-  '&:active'?: CSSProperties;
-  '&:disabled'?: CSSProperties;
-  '&:focus'?: CSSProperties;
-
   /** Children */
   '&>*'?: CSSProperties;
-  '&:first-child'?: CSSProperties;
-  '&:last-child'?: CSSProperties;
 
   /**
    * Mobile first media query example
@@ -1671,21 +1712,10 @@ type NestedCSSSelectors = {
    * e.g. style({ desktop, '@media' : notDesktop });
    **/
   '@media screen and (max-width: 700px)'?: CSSProperties;
-  '@font-face'?: FontFace;
-  [selector: string]: CSSProperties | FontFace | undefined;
+  [selector: string]: CSSProperties | undefined;
 };
 
 type CSSProperties = CSSPropertyMap & NestedCSSProperties;
-
-type FontFace = {
-  fontFamily?: string;
-  src?: string;
-  unicodeRange?: any;
-  fontVariant?: 'common-ligatures' | 'small-caps' | CSSGlobalValues;
-  fontFeatureSettings?: string;
-  fontWeight?: 'normal' | 'bold' | 'bolder' | 'lighter' | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | CSSGlobalValues;
-  fontSize?: 'normal' | 'italic' | 'oblique' | CSSGlobalValues;
-}
 
 /**
  * For animation keyframe definition

--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -200,7 +200,8 @@ type CSSUrl = string | CSSType<'url'>;
 /**
  * This interface documents key CSS properties for autocomplete
  */
-type CSSPropertyMap = {
+interface CSSProperties {
+  /** Smooth scrolling on an iPhone */
   '-webkit-overflow-scrolling'?: string;
 
   /**
@@ -1644,7 +1645,7 @@ type CSSPropertyMap = {
   zoom?: "auto" | number;
 }
 
-type NestedCSSProperties = {
+interface NestedCSSProperties extends CSSProperties {
   nested?: NestedCSSSelectors;
 }
 
@@ -1719,8 +1720,6 @@ type NestedCSSSelectors = {
   [selector: string]: CSSProperties | undefined;
 };
 
-type CSSProperties = CSSPropertyMap & NestedCSSProperties;
-
 /**
  * For animation keyframe definition
  */
@@ -1728,5 +1727,5 @@ interface KeyFrames {
   [
   /** stuff like `from`, `to` or `10%` etc*/
   key: string
-  ]: CSSPropertyMap;
+  ]: NestedCSSProperties;
 }

--- a/src/csx/color.ts
+++ b/src/csx/color.ts
@@ -1,5 +1,6 @@
 import { cssFunction } from '../';
-import { ensurePercent, formatPercent } from '../formatting'
+import { ensurePercent, formatPercent } from '../formatting';
+import * as types from "../types";
 
 const isTypeArraySupported = typeof Float32Array !== 'undefined';
 
@@ -29,7 +30,7 @@ const maxChannelValues = {
  * Creates a color from a hex color code or named color.
  * e.g. color('red') or color('#FF0000') or color('#F00'))
  */
-export function color(value: CSSNamedColor | string): ColorHelper {
+export function color(value: types.CSSNamedColor | string): ColorHelper {
   return parseNamedColor(value) || parseHexCode(value) || parseNamedColor('red') !;
 }
 
@@ -234,7 +235,7 @@ export class ColorHelper {
     return new ColorHelper(this._format, v[R], v[G], v[B], a, true);
   }
 
-  public mix(mixin: CSSColor, weight?: number): ColorHelper {
+  public mix(mixin: types.CSSColor, weight?: number): ColorHelper {
     const color1 = this;
     const color2 = ensureColor(mixin);
     const c1 = (color1._format === RGB ? color1 : color1.toRGB())._values;
@@ -410,12 +411,12 @@ export const {aliceblue, antiquewhite, aqua, aquamarine, azure, beige, bisque, b
   rebeccapurple, red, silver, teal, transparent, white, yellow } = namedColors;
 
 function toHex(n: number): string {
-  return (n < 16 ? '0' : '') +  Math.round(n).toString(16);
+  return (n < 16 ? '0' : '') + Math.round(n).toString(16);
 }
 
 function modDegrees(n: number): number {
   // note: maybe there is a way to simplify this
-  return  ((n < 0 ? 360 : 0) + (n % 360)) % 360;
+  return ((n < 0 ? 360 : 0) + (n % 360)) % 360;
 }
 
 function roundFloat(n: number, places: number): number {
@@ -536,7 +537,7 @@ function clampColor(format: number, channel: number, value: number): number {
   return value < min ? min : value > max ? max : value;
 }
 
-function ensureColor(c: CSSColor): ColorHelper {
+function ensureColor(c: types.CSSColor): ColorHelper {
   return c instanceof ColorHelper ? c as ColorHelper : color(c as string);
 }
 

--- a/src/csx/display.ts
+++ b/src/csx/display.ts
@@ -1,19 +1,20 @@
 /**
  * @module provide display helpers
  */
+import * as types from '../types';
 
-export var block: CSSProperties = {
+export var block: types.CSSProperties = {
   display: 'block'
 };
 
-export var none: CSSProperties = {
+export var none: types.CSSProperties = {
   display: 'none'
 };
 
-export var inlineBlock: CSSProperties = {
+export var inlineBlock: types.CSSProperties = {
   display: 'inline-block'
 };
 
-export var invisible: CSSProperties = {
+export var invisible: types.CSSProperties = {
   visibility: 'hidden'
 };

--- a/src/csx/flex.ts
+++ b/src/csx/flex.ts
@@ -5,11 +5,12 @@
  * -ms- is needed for IE
  */
 import { extend } from '../';
+import * as types from '../types';
 
 /**
  * If you have more than one child prefer horizontal,vertical
  */
-export var flexRoot: CSSProperties = {
+export var flexRoot: types.CSSProperties = {
   display: [
     '-ms-flexbox',
     '-webkit-flex',
@@ -25,7 +26,7 @@ export var flexRoot: CSSProperties = {
  *    </pass>
  * </vertical>
  */
-export var pass: CSSProperties = {
+export var pass: types.CSSProperties = {
   display: 'inherit',
 
   '-ms-flex-direction': 'inherit',
@@ -37,7 +38,7 @@ export var pass: CSSProperties = {
   flexGrow: 1,
 }
 
-export var inlineRoot: CSSProperties = {
+export var inlineRoot: types.CSSProperties = {
   display: [
     '-ms-inline-flexbox',
     '-webkit-inline-flex',
@@ -45,18 +46,18 @@ export var inlineRoot: CSSProperties = {
   ]
 };
 
-export const horizontal: CSSProperties = extend(flexRoot, {
+export const horizontal: types.CSSProperties = extend(flexRoot, {
   '-ms-flex-direction': 'row',
   '-webkit-flex-direction': 'row',
   flexDirection: 'row'
 });
-export const vertical: CSSProperties = extend(flexRoot, {
+export const vertical: types.CSSProperties = extend(flexRoot, {
   '-ms-flex-direction': 'column',
   '-webkit-flex-direction': 'column',
   flexDirection: 'column'
 });
 
-export var wrap: CSSProperties = {
+export var wrap: types.CSSProperties = {
   '-ms-flex-wrap': 'wrap',
   '-webkit-flex-wrap': 'wrap',
   flexWrap: 'wrap'
@@ -67,71 +68,71 @@ export var wrap: CSSProperties = {
  * This is because of a bug in various flexbox implementations: http://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/
  * Specifically bug 1 : https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored
  */
-export var content: CSSProperties = {
+export var content: types.CSSProperties = {
   '-ms-flex-negative': 0,
   '-webkit-flex-shrink': 0,
   flexShrink: 0,
   flexBasis: 'auto',
 };
 
-export var flex: CSSProperties = {
+export var flex: types.CSSProperties = {
   '-ms-flex': 1,
   '-webkit-flex': 1,
   flex: 1
 };
 
-export var flex1: CSSProperties = flex;
-export var flex2: CSSProperties = {
+export var flex1: types.CSSProperties = flex;
+export var flex2: types.CSSProperties = {
   '-ms-flex': 2,
   '-webkit-flex': 2,
   flex: 2
 };
-export var flex3: CSSProperties = {
+export var flex3: types.CSSProperties = {
   '-ms-flex': 3,
   '-webkit-flex': 3,
   flex: 3
 };
-export var flex4: CSSProperties = {
+export var flex4: types.CSSProperties = {
   '-ms-flex': 4,
   '-webkit-flex': 4,
   flex: 4
 };
-export var flex5: CSSProperties = {
+export var flex5: types.CSSProperties = {
   '-ms-flex': 5,
   '-webkit-flex': 5,
   flex: 5
 };
-export var flex6: CSSProperties = {
+export var flex6: types.CSSProperties = {
   '-ms-flex': 6,
   '-webkit-flex': 6,
   flex: 6
 };
-export var flex7: CSSProperties = {
+export var flex7: types.CSSProperties = {
   '-ms-flex': 7,
   '-webkit-flex': 7,
   flex: 7
 };
-export var flex8: CSSProperties = {
+export var flex8: types.CSSProperties = {
   '-ms-flex': 8,
   '-webkit-flex': 8,
   flex: 8
 };
-export var flex9: CSSProperties = {
+export var flex9: types.CSSProperties = {
   '-ms-flex': 9,
   '-webkit-flex': 9,
   flex: 9
 };
-export var flex10: CSSProperties = {
+export var flex10: types.CSSProperties = {
   '-ms-flex': 10,
   '-webkit-flex': 10,
   flex: 10
 };
-export var flex11: CSSProperties = {
+export var flex11: types.CSSProperties = {
   '-ms-flex': 11,
   '-webkit-flex': 11,
   flex: 11
 };
-export var flex12: CSSProperties = {
+export var flex12: types.CSSProperties = {
   '-ms-flex': 12,
   '-webkit-flex': 12,
   flex: 12
@@ -141,17 +142,17 @@ export var flex12: CSSProperties = {
 // Alignment in cross axis //
 /////////////////////////////
 
-export var start: CSSProperties = {
+export var start: types.CSSProperties = {
   '-ms-flex-align': 'start',
   '-webkit-align-items': 'flex-start',
   alignItems: 'flex-start'
 };
-export var center: CSSProperties = {
+export var center: types.CSSProperties = {
   '-ms-flex-align': 'center',
   '-webkit-align-items': 'center',
   alignItems: 'center'
 };
-export var end: CSSProperties = {
+export var end: types.CSSProperties = {
   '-ms-flex-align': 'end',
   '-webkit-align-items': 'flex-end',
   alignItems: 'flex-end'
@@ -161,27 +162,27 @@ export var end: CSSProperties = {
 // Alignment in main axis //
 ////////////////////////////
 
-export var startJustified: CSSProperties = {
+export var startJustified: types.CSSProperties = {
   '-ms-flex-pack': 'start',
   '-webkit-justify-content': 'flex-start',
   justifyContent: 'flex-start'
 };
-export var centerJustified: CSSProperties = {
+export var centerJustified: types.CSSProperties = {
   '-ms-flex-pack': 'center',
   '-webkit-justify-content': 'center',
   justifyContent: 'center'
 };
-export var endJustified: CSSProperties = {
+export var endJustified: types.CSSProperties = {
   '-ms-flex-pack': 'end',
   '-webkit-justify-content': 'flex-end',
   justifyContent: 'flex-end'
 };
-export var aroundJustified: CSSProperties = {
+export var aroundJustified: types.CSSProperties = {
   '-ms-flex-pack': 'distribute',
   '-webkit-justify-content': 'space-around',
   justifyContent: 'space-around'
 };
-export var betweenJustified: CSSProperties = {
+export var betweenJustified: types.CSSProperties = {
   '-ms-flex-pack': 'justify',
   '-webkit-justify-content': 'space-between',
   justifyContent: 'space-between'
@@ -191,28 +192,28 @@ export var betweenJustified: CSSProperties = {
 // Alignment in both axes //
 ////////////////////////////
 
-export var centerCenter: CSSProperties = extend(flexRoot, center, centerJustified);
+export var centerCenter: types.CSSProperties = extend(flexRoot, center, centerJustified);
 
 ////////////////////
 // Self alignment //
 ////////////////////
 
-export var selfStart: CSSProperties = {
+export var selfStart: types.CSSProperties = {
   '-ms-flex-item-align': 'start',
   '-webkit-align-self': 'flex-start',
   alignSelf: 'flex-start'
 };
-export var selfCenter: CSSProperties = {
+export var selfCenter: types.CSSProperties = {
   '-ms-flex-item-align': 'center',
   '-webkit-align-self': 'center',
   alignSelf: 'center'
 };
-export var selfEnd: CSSProperties = {
+export var selfEnd: types.CSSProperties = {
   '-ms-flex-item-align': 'end',
   '-webkit-align-self': 'flex-end',
   alignSelf: 'flex-end'
 };
-export var selfStretch: CSSProperties = {
+export var selfStretch: types.CSSProperties = {
   '-ms-flex-item-align': 'stretch',
   '-webkit-align-self': 'stretch',
   alignSelf: 'stretch',

--- a/src/csx/font.ts
+++ b/src/csx/font.ts
@@ -1,7 +1,8 @@
 /**
  * @module font helpers / mixins
  */
+import * as types from '../types';
 
-export const fontStyleItalic: CSSProperties = { fontStyle: 'italic' };
-export const fontWeightNormal: CSSProperties = { fontWeight: 'normal' };
-export const fontWeightBold: CSSProperties = { fontWeight: 'bold' };
+export const fontStyleItalic: types.CSSProperties = { fontStyle: 'italic' };
+export const fontWeightNormal: types.CSSProperties = { fontWeight: 'normal' };
+export const fontWeightBold: types.CSSProperties = { fontWeight: 'bold' };

--- a/src/csx/gradient.ts
+++ b/src/csx/gradient.ts
@@ -1,10 +1,11 @@
 import { cssFunction, ensureString } from '../';
+import * as types from '../types';
 
 /**
  * Helper for the linear-gradient function in CSS
  * https://drafts.csswg.org/css-images-3/#funcdef-linear-gradient
  */
-export function linearGradient(position: CSSAngle | CSSSideOrCorner, ...colors: (CSSColor | CSSColorStop)[]): CSSType<'gradient'> {
+export function linearGradient(position: types.CSSAngle | types.CSSSideOrCorner, ...colors: (types.CSSColor | types.CSSColorStop)[]): types.CSSType<'gradient'> {
   return {
     type: 'gradient',
     toString: () => cssFunction('linear-gradient', position, ...colors.map(flattenColorStops))
@@ -15,7 +16,7 @@ export function linearGradient(position: CSSAngle | CSSSideOrCorner, ...colors: 
  * Helper for the repeating-linear-gradient function in CSS
  * https://drafts.csswg.org/css-images-3/#funcdef-repeating-linear-gradient
  */
-export function repeatingLinearGradient(position: CSSSideOrCorner, ...colors: (CSSColor | CSSColorStop)[]): CSSType<'gradient'> {
+export function repeatingLinearGradient(position: types.CSSSideOrCorner, ...colors: (types.CSSColor | types.CSSColorStop)[]): types.CSSType<'gradient'> {
   return {
     type: 'gradient',
     toString: () => cssFunction('repeating-linear-gradient', position, ...colors.map(flattenColorStops))
@@ -27,6 +28,6 @@ export function repeatingLinearGradient(position: CSSSideOrCorner, ...colors: (C
  * 'x'=>'x'
  * ['x', '50%'] => 'x 50%'
  **/
-function flattenColorStops(c: (CSSColor | CSSColorStop)): string {
+function flattenColorStops(c: (types.CSSColor | types.CSSColorStop)): string {
   return Array.isArray(c) ? c.map(ensureString).join(' ') : ensureString(c);
 }

--- a/src/csx/layer.ts
+++ b/src/csx/layer.ts
@@ -2,11 +2,12 @@
  * @module Layers essentially allow you to create a new surface for layouts
  */
 import { extend } from '../';
+import * as types from '../types';
 
 /**
  * New layer parent
  */
-export var layerParent: CSSProperties = {
+export var layerParent: types.CSSProperties = {
   position: 'relative',
 };
 
@@ -14,7 +15,7 @@ export var layerParent: CSSProperties = {
  * Use this to attach to any parent layer
  * and then you can use `left`/`top` etc to position yourself
  */
-export const attachToLayerParent: CSSProperties = {
+export const attachToLayerParent: types.CSSProperties = {
   position: 'absolute',
 };
 
@@ -22,7 +23,7 @@ export const attachToLayerParent: CSSProperties = {
  * This new layer will attach itself to the nearest parent with `position:relative` or `position:absolute`
  * And will become the new `layerParent`
  */
-export var newLayer: CSSProperties = extend(
+export var newLayer: types.CSSProperties = extend(
   attachToLayerParent,
   {
     left: 0,
@@ -32,7 +33,7 @@ export var newLayer: CSSProperties = extend(
   }
 );
 
-export const attachToTop: CSSProperties = extend(
+export const attachToTop: types.CSSProperties = extend(
   attachToLayerParent,
   {
     top: 0,
@@ -40,7 +41,7 @@ export const attachToTop: CSSProperties = extend(
     right: 0,
   }
 );
-export const attachToRight: CSSProperties = extend(
+export const attachToRight: types.CSSProperties = extend(
   attachToLayerParent,
   {
     top: 0,
@@ -48,7 +49,7 @@ export const attachToRight: CSSProperties = extend(
     bottom: 0,
   }
 );
-export const attachToBottom: CSSProperties = extend(
+export const attachToBottom: types.CSSProperties = extend(
   attachToLayerParent,
   {
     right: 0,
@@ -56,7 +57,7 @@ export const attachToBottom: CSSProperties = extend(
     left: 0,
   }
 );
-export const attachToLeft: CSSProperties = extend(
+export const attachToLeft: types.CSSProperties = extend(
   attachToLayerParent,
   {
     top: 0,
@@ -68,26 +69,26 @@ export const attachToLeft: CSSProperties = extend(
 /**
  * Helps fixing to page
  */
-const fixed: CSSProperties = {
+const fixed: types.CSSProperties = {
   position: 'fixed'
 };
 
-export const pageTop: CSSProperties = extend(fixed, {
+export const pageTop: types.CSSProperties = extend(fixed, {
   top: 0,
   left: 0,
   right: 0,
 });
-export const pageRight: CSSProperties = extend(fixed, {
+export const pageRight: types.CSSProperties = extend(fixed, {
   top: 0,
   right: 0,
   bottom: 0,
 });
-export const pageBottom: CSSProperties = extend(fixed, {
+export const pageBottom: types.CSSProperties = extend(fixed, {
   right: 0,
   bottom: 0,
   left: 0,
 });
-export const pageLeft: CSSProperties = extend(fixed, {
+export const pageLeft: types.CSSProperties = extend(fixed, {
   top: 0,
   bottom: 0,
   left: 0,

--- a/src/csx/scroll.ts
+++ b/src/csx/scroll.ts
@@ -1,17 +1,19 @@
 /**
  * @module scroll helpers
  */
-export const scroll: CSSProperties = {
+import * as types from '../types';
+
+export const scroll: types.CSSProperties = {
   '-webkit-overflow-scrolling': 'touch',
   overflow: 'auto'
 };
 
-export const scrollX: CSSProperties = {
+export const scrollX: types.CSSProperties = {
   '-webkit-overflow-scrolling': 'touch',
   overflowX: 'auto'
 };
 
-export const scrollY: CSSProperties = {
+export const scrollY: types.CSSProperties = {
   '-webkit-overflow-scrolling': 'touch',
   overflowY: 'auto'
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,7 @@ export function extend(...objects: NestedCSSProperties[]): NestedCSSProperties {
     for (const key in object) {
 
       /** Falsy values except a explicit 0 is ignored */
-      const val: any = object[key];
+      const val: any = (object as any)[key];
       if (!val && val !== 0) {
         continue;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,7 @@ export function extend(...objects: NestedCSSProperties[]): NestedCSSProperties {
     for (const key in object) {
 
       /** Falsy values except a explicit 0 is ignored */
-      const val = object[key];
+      const val: any = object[key];
       if (!val && val !== 0) {
         continue;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,8 @@ export function extend(...objects: CSSProperties[]): CSSProperties {
   const result: CSSProperties & Dictionary = {};
   for (const object of objects as (CSSProperties & Dictionary)[]) {
     for (const key in object) {
+
+      /** Falsy values except a explicit 0 is ignored */
       const val = object[key];
       if (!val && val !== 0) {
         continue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ import * as FreeStyle from "free-style";
 /** Raf for node + browser */
 const raf = typeof requestAnimationFrame === 'undefined' ? setTimeout : requestAnimationFrame;
 
-const startsWith = (target: string, val: string): boolean =>  target.indexOf(val) === 0;
 /**
  * Only calls cb all sync operations settle
  */
@@ -203,11 +202,7 @@ export function extend(...objects: CSSProperties[]): CSSProperties {
         continue;
       }
 
-      // if pseudo selector
-      if (startsWith(key, '&:')) {
-        result[key] = result[key] ? extend(result[key] as any, val) : ensureStringObj(val);
-      }
-      // if media
+      // if media or pseudo selector
       else if (key === 'nested' && val) {
         const nested = object.nested!;
         for (let selector in nested) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ export function extend(...objects: CSSProperties[]): CSSProperties {
 
       // if freestyle media or pseudo selector
       if ((key.indexOf('&') !== -1 || key.indexOf('@media') === 0)) {
-        result[key] = result[key] ? extend(result[key] as any, object[key]) : ensureStringObj(val);
+        result[key] = result[key] ? extend(result[key] as any, val) : ensureStringObj(val);
       }
 
       // if nested media or pseudo selector

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,8 +206,9 @@ export function extend(...objects: CSSProperties[]): CSSProperties {
 
       // if freestyle media or pseudo selector
       if ((key.indexOf('&') !== -1 || key.indexOf('@media') === 0)) {
-        result[key] = result[key] ? extend(result[key] as any, object) : ensureStringObj(val);
+        result[key] = result[key] ? extend(result[key] as any, object[key]) : ensureStringObj(val);
       }
+
       // if nested media or pseudo selector
       else if (key === 'nested' && val) {
         const nested = object.nested!;

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ const {setTag, getTag} = new class {
   setTag = (tag: { innerHTML: string }) => {
     this.singletonTag = tag;
     /** This special time buffer immediately */
-    forceFlush();
+    forceRender();
   }
 };
 
@@ -87,7 +87,7 @@ const styleUpdated = () => {
 
   lastFreeStyleChangeId = freeStyle.changeId;
   pendingRawChange = false;
-  afterAllSync(forceFlush);
+  afterAllSync(forceRender);
 };
 
 let pendingRawChange = false;
@@ -107,9 +107,11 @@ export function cssRaw(mustBeValidCSS: string) {
 }
 
 /**
- * Flushes styles to the singleton tag
+ * Renders styles to the singleton tag imediately
+ * NOTE: You should only call it on initial render to prevent any non CSS flash.
+ * After that it is kept sync using `requestAnimationFrame` and we haven't noticed any bad flashes.
  **/
-export function forceFlush() {
+export function forceRender() {
   getTag().innerHTML = css();
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ const {setTag, getTag} = new class {
     }
     return this.singletonTag;
   }
-  setTag = (tag: {innerHTML: string}) => {
+  setTag = (tag: { innerHTML: string }) => {
     this.singletonTag = tag;
     /** This special time buffer immediately */
     forceFlush();
@@ -202,7 +202,11 @@ export function extend(...objects: CSSProperties[]): CSSProperties {
         continue;
       }
 
-      // if media or pseudo selector
+      // if freestyle media or pseudo selector
+      if ((key.indexOf('&') !== -1 || key.indexOf('@media') === 0)) {
+        result[key] = result[key] ? extend(result[key] as any, object) : ensureStringObj(val);
+      }
+      // if nested media or pseudo selector
       else if (key === 'nested' && val) {
         const nested = object.nested!;
         for (let selector in nested) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ const {setTag, getTag} = new class {
 };
 
 /** Sets the tag where we write the CSS on style updates */
-export const setTarget = setTag;
+export const target = setTag;
 
 /** Checks if the style tag needs updating and if so queues up the change */
 const styleUpdated = () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ export const css = () => raw ? raw + freeStyle.getStyles() : freeStyle.getStyles
 /**
  * Takes CSSProperties and return a generated className you can use on your component
  */
-export function style(...objects: CSSProperties[]) {
+export function style(...objects: NestedCSSProperties[]) {
   const object = extend(...objects);
   const className = freeStyle.registerStyle(object);
   styleUpdated();
@@ -155,7 +155,7 @@ export function fontFace(...fontFace: FontFace[]): void {
 /**
  * Takes CSSProperties and registers it to a global selector (body, html, etc.)
  */
-export function cssRule(selector: string, ...objects: CSSProperties[]): void {
+export function cssRule(selector: string, ...objects: NestedCSSProperties[]): void {
   const object = extend(...objects);
   freeStyle.registerRule(selector, object);
   styleUpdated();
@@ -192,10 +192,10 @@ export function cssFunction(functionName: string, ...params: CSSValueGeneral[]):
  * Merges various styles into a single style object.
  * Note: if two objects have the same property the last one wins
  */
-export function extend(...objects: CSSProperties[]): CSSProperties {
+export function extend(...objects: NestedCSSProperties[]): NestedCSSProperties {
   /** The final result we will return */
   const result: CSSProperties & Dictionary = {};
-  for (const object of objects as (CSSProperties & Dictionary)[]) {
+  for (const object of objects) {
     for (const key in object) {
 
       /** Falsy values except a explicit 0 is ignored */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-/// <reference path="./css.d.ts"/>
+import * as types from "./types";
 
 /**
  * @module Maintains a single stylesheet and keeps it in sync with requested styles
@@ -32,7 +32,7 @@ type Dictionary = { [key: string]: any; };
  * Call this whenever something might be a CSSType.
  */
 export function ensureString(x: any): string {
-  return typeof (x as CSSType<any>).type === 'string'
+  return typeof (x as types.CSSType<any>).type === 'string'
     ? x.toString()
     : x;
 }
@@ -40,8 +40,8 @@ export function ensureString(x: any): string {
 /**
  * Ensures string for all values of an object
  */
-export function ensureStringObj(object: any): CSSProperties {
-  const result: CSSProperties & Dictionary = {};
+export function ensureStringObj(object: any): types.CSSProperties {
+  const result: types.CSSProperties & Dictionary = {};
   for (const key in object) {
     const val = object[key];
     result[key] = ensureString(val);
@@ -139,14 +139,14 @@ export const css = () => raw ? raw + freeStyle.getStyles() : freeStyle.getStyles
 /**
  * Takes CSSProperties and return a generated className you can use on your component
  */
-export function style(...objects: NestedCSSProperties[]) {
+export function style(...objects: types.NestedCSSProperties[]) {
   const object = extend(...objects);
   const className = freeStyle.registerStyle(object);
   styleUpdated();
   return className;
 }
 
-export function fontFace(...fontFace: FontFace[]): void {
+export function fontFace(...fontFace: types.FontFace[]): void {
   for (const face of fontFace) {
     freeStyle.registerRule('@font-face', face);
   }
@@ -157,7 +157,7 @@ export function fontFace(...fontFace: FontFace[]): void {
 /**
  * Takes CSSProperties and registers it to a global selector (body, html, etc.)
  */
-export function cssRule(selector: string, ...objects: NestedCSSProperties[]): void {
+export function cssRule(selector: string, ...objects: types.NestedCSSProperties[]): void {
   const object = extend(...objects);
   freeStyle.registerRule(selector, object);
   styleUpdated();
@@ -167,7 +167,7 @@ export function cssRule(selector: string, ...objects: NestedCSSProperties[]): vo
 /**
  * Takes Keyframes and returns a generated animation name
  */
-export function keyframes(frames: KeyFrames) {
+export function keyframes(frames: types.KeyFrames) {
   // resolve keyframe css property helpers
   for (const key in frames) {
     const frame = frames[key] as Dictionary;
@@ -185,7 +185,7 @@ export function keyframes(frames: KeyFrames) {
  * Assumption is that most css function fall into this pattern:
  * `function-name(param [, param])`
  */
-export function cssFunction(functionName: string, ...params: CSSValueGeneral[]): string {
+export function cssFunction(functionName: string, ...params: types.CSSValueGeneral[]): string {
   const parts = params.map(ensureString).join(',');
   return `${functionName}(${parts})`;
 }
@@ -194,9 +194,9 @@ export function cssFunction(functionName: string, ...params: CSSValueGeneral[]):
  * Merges various styles into a single style object.
  * Note: if two objects have the same property the last one wins
  */
-export function extend(...objects: NestedCSSProperties[]): NestedCSSProperties {
+export function extend(...objects: types.NestedCSSProperties[]): types.NestedCSSProperties {
   /** The final result we will return */
-  const result: CSSProperties & Dictionary = {};
+  const result: types.CSSProperties & Dictionary = {};
   for (const object of objects) {
     for (const key in object) {
 
@@ -238,7 +238,7 @@ export function classes(...classes: (string | boolean | undefined | null)[]): st
 /**
  * Helps customize styles with media queries
  */
-export const media = (mediaQuery: MediaQuery, ...objects: CSSProperties[]): CSSProperties => {
+export const media = (mediaQuery: types.MediaQuery, ...objects: types.CSSProperties[]): types.CSSProperties => {
   const mediaQuerySections: string[] = [];
   if (mediaQuery.type) mediaQuerySections.push(mediaQuery.type);
   if (mediaQuery.orientation) mediaQuerySections.push(mediaQuery.orientation);

--- a/src/tests/basic.tsx
+++ b/src/tests/basic.tsx
@@ -32,7 +32,12 @@ describe("initial test", () => {
 
   it("media same", () => {
     reinit();
-    style({ color: 'red', nested: { '@media (min-width: 400px)': { color: 'red' } } });
+    style({
+      color: 'red',
+      nested: {
+        '@media (min-width: 400px)': { color: 'red' }
+      }
+    });
     assert.equal(css(), '.f12z113b{color:red}@media (min-width: 400px){.f12z113b{color:red}}');
   });
 

--- a/src/tests/basic.tsx
+++ b/src/tests/basic.tsx
@@ -20,25 +20,25 @@ describe("initial test", () => {
 
   it("child same", () => {
     reinit();
-    style({ color: 'red', '&>*': { color: 'red' } });
+    style({ color: 'red', nested: { '&>*': { color: 'red' } } });
     assert.equal(css(), '.f1nv0def,.f1nv0def>*{color:red}');
   });
 
   it("child different", () => {
     reinit();
-    style({ color: 'red', '&>*': { color: 'blue' } });
+    style({ color: 'red', nested: { '&>*': { color: 'blue' } } });
     assert.equal(css(), '.fv84gyi{color:red}.fv84gyi>*{color:blue}');
   });
 
   it("media same", () => {
     reinit();
-    style({ color: 'red', '@media (min-width: 400px)': { color: 'red' } });
+    style({ color: 'red', nested: { '@media (min-width: 400px)': { color: 'red' } } });
     assert.equal(css(), '.f12z113b{color:red}@media (min-width: 400px){.f12z113b{color:red}}');
   });
 
   it("media different", () => {
     reinit();
-    style({ color: 'red', '@media (min-width: 400px)': { color: 'blue' } });
+    style({ color: 'red', nested: { '@media (min-width: 400px)': { color: 'blue' } } });
     assert.equal(css(), '.fxfrsga{color:red}@media (min-width: 400px){.fxfrsga{color:blue}}');
   });
 

--- a/src/tests/csx/color.ts
+++ b/src/tests/csx/color.ts
@@ -73,8 +73,10 @@ describe('color', () => {
     it('handles hsl in style with & interpolation', () => {
       reinit();
       style({
-        '&:hover': {
-          backgroundColor: hsl(0, '100%', '50%'),
+        nested: {
+          '&:hover': {
+            backgroundColor: hsl(0, '100%', '50%'),
+          }
         }
       });
       assert.equal(css(), '.f5pxp3d:hover{background-color:hsl(0,100%,50%)}');

--- a/src/tests/csx/color.ts
+++ b/src/tests/csx/color.ts
@@ -73,11 +73,9 @@ describe('color', () => {
     it('handles hsl in style with & interpolation', () => {
       reinit();
       style({
-        nested: {
-          '&:hover': {
+        '&:hover': {
             backgroundColor: hsl(0, '100%', '50%'),
           }
-        }
       });
       assert.equal(css(), '.f5pxp3d:hover{background-color:hsl(0,100%,50%)}');
     });

--- a/src/tests/csx/color.ts
+++ b/src/tests/csx/color.ts
@@ -73,9 +73,11 @@ describe('color', () => {
     it('handles hsl in style with & interpolation', () => {
       reinit();
       style({
-        '&:hover': {
+        nested: {
+          '&:hover': {
             backgroundColor: hsl(0, '100%', '50%'),
           }
+        }
       });
       assert.equal(css(), '.f5pxp3d:hover{background-color:hsl(0,100%,50%)}');
     });

--- a/src/tests/extend.ts
+++ b/src/tests/extend.ts
@@ -9,6 +9,20 @@ describe("extend", () => {
   it("nested objects should get flattened", () => {
     assert.deepEqual(
       extend(
+        {
+          nested: { '&:hover': { color: 'red' } }
+        },
+      ),
+      {
+        '&:hover': {
+          color: 'red'
+        }
+      });
+  });
+
+  it("nested objects should get flattened and merge", () => {
+    assert.deepEqual(
+      extend(
         { color: 'grey' },
         { nested: { '&:hover': { color: 'red' } } },
       ),

--- a/src/tests/extend.ts
+++ b/src/tests/extend.ts
@@ -51,4 +51,18 @@ describe("extend", () => {
         }
       });
   });
+
+  it("extend should compose i.e. should be truly nestable", () => {
+    assert.deepEqual(
+      extend(
+        extend({ nested: { '&:hover': { color: 'red' } } }),
+        extend({ nested: { '&:hover': { backgroundColor: 'red' } } }),
+      ),
+      {
+        '&:hover': {
+          color: 'red',
+          backgroundColor: 'red'
+        }
+      });
+  });
 });

--- a/src/tests/extend.ts
+++ b/src/tests/extend.ts
@@ -1,0 +1,40 @@
+import { extend } from '../index';
+import * as assert from 'assert';
+
+describe("extend", () => {
+  it("plain objects should be preserved", () => {
+    assert.deepEqual(extend({ color: 'red' }), { color: 'red' });
+  });
+
+  it("nested objects should get flattened", () => {
+    assert.deepEqual(
+      extend(
+        { color: 'grey' },
+        { nested: { '&:hover': { color: 'red' } } },
+      ),
+      {
+        color: 'grey',
+        '&:hover': {
+          color: 'red'
+        }
+      });
+  });
+
+  it("nested objects should merge", () => {
+    assert.deepEqual(
+      extend(
+        { color: 'grey' },
+        { backgroundColor: 'grey' },
+        { nested: { '&:hover': { color: 'red' } } },
+        { nested: { '&:hover': { backgroundColor: 'red' } } },
+      ),
+      {
+        color: 'grey',
+        backgroundColor: 'grey',
+        '&:hover': {
+          color: 'red',
+          backgroundColor: 'red'
+        }
+      });
+  });
+});

--- a/src/tests/extend.ts
+++ b/src/tests/extend.ts
@@ -37,4 +37,18 @@ describe("extend", () => {
         }
       });
   });
+
+  it("extend should compose i.e. should be nestable", () => {
+    assert.deepEqual(
+      extend(
+        extend({ nested: { '&:hover': { color: 'red' } } }),
+        { nested: { '&:hover': { backgroundColor: 'red' } } },
+      ),
+      {
+        '&:hover': {
+          color: 'red',
+          backgroundColor: 'red'
+        }
+      });
+  });
 });

--- a/src/tests/extend.ts
+++ b/src/tests/extend.ts
@@ -79,4 +79,25 @@ describe("extend", () => {
         }
       });
   });
+
+  it("different nested keys should not merge", () => {
+    assert.deepEqual(
+      extend(
+        { nested: { '&:hover': { color: 'red' } } },
+        { nested: { '&:hover': { backgroundColor: 'red' } } },
+        { nested: { '&:focus': { backgroundColor: 'red' } } },
+        { nested: { '&:hover': { fontSize: '14px' }, '&:focus': { fontFamily: 'arial' } } },
+      ),
+      {
+        '&:hover': {
+          fontSize: '14px',
+          color: 'red',
+          backgroundColor: 'red'
+        },
+        '&:focus': {
+          fontFamily: 'arial',
+          backgroundColor: 'red'
+        }
+      });
+  });
 });

--- a/src/tests/fontFace.tsx
+++ b/src/tests/fontFace.tsx
@@ -1,0 +1,17 @@
+import { css, reinit, fontFace } from '../index';
+import * as assert from 'assert';
+
+describe("fontFace", () => {
+
+  it('support font faces', () => {
+    reinit();
+
+    fontFace({
+      fontFamily: '"Bitstream Vera Serif Bold"',
+      src: 'url("https://mdn.mozillademos.org/files/2468/VeraSeBd.ttf")'
+    });
+
+    assert.equal(css(), '@font-face{font-family:"Bitstream Vera Serif Bold";src:url("https://mdn.mozillademos.org/files/2468/VeraSeBd.ttf")}');
+  })
+
+});

--- a/src/tests/media.ts
+++ b/src/tests/media.ts
@@ -4,10 +4,16 @@ import * as assert from 'assert';
 describe("media query", () => {
   it("standard freestyle", () => {
     reinit();
-    style({ color: 'red', nested: { '@media (min-width: 400px)': { color: 'red' } } });
+    style({
+      color: 'red',
+      nested: {
+        '@media (min-width: 400px)': { color: 'red' }
+      }
+    });
     const standardFreeStyle = css();
     reinit();
-    style({ color: 'red' }, media({ minWidth: 400 }, { color: 'red' }));
+    style({ color: 'red' }, media({
+      minWidth: 400 }, { color: 'red' }));
     assert.equal(css(), standardFreeStyle);
   });
 

--- a/src/tests/media.ts
+++ b/src/tests/media.ts
@@ -4,7 +4,7 @@ import * as assert from 'assert';
 describe("media query", () => {
   it("standard freestyle", () => {
     reinit();
-    style({ color: 'red', '@media (min-width: 400px)': { color: 'red' } });
+    style({ color: 'red', nested: { '@media (min-width: 400px)': { color: 'red' } } });
     const standardFreeStyle = css();
     reinit();
     style({ color: 'red' }, media({ minWidth: 400 }, { color: 'red' }));

--- a/src/tests/rule.tsx
+++ b/src/tests/rule.tsx
@@ -58,23 +58,16 @@ describe("test rules", () => {
     assert.equal(css(), 'html, body{height:100%;margin:0;padding:0;width:100%}html{box-sizing:border-box}*,*:before,*:after{box-sizing:inherit}');
   });
 
-  it('support font faces', () => {
-    reinit();
-    cssRule('@font-face', {
-      fontFamily: '"Bitstream Vera Serif Bold"',
-      src: 'url("https://mdn.mozillademos.org/files/2468/VeraSeBd.ttf")'
-    });
-    assert.equal(css(), '@font-face{font-family:"Bitstream Vera Serif Bold";src:url("https://mdn.mozillademos.org/files/2468/VeraSeBd.ttf")}');
-  })
-
   it('support global media queries', () => {
     reinit();
     /** Save ink with a white background */
     cssRule('@media print', {
-      body: {
-        background: 'white'
+      nested: {
+        body: {
+          background: 'white'
+        }
       }
     });
     assert.equal(css(), '@media print{body{background:white}}');
-  })
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,14 @@
-
-
 /**
  * Value of a CSS Property.  Could be a single value or a list of fallbacks
  * NOTE: array is for fallbacks
  */
-type CSSValue<T> = T | T[];
+export type CSSValue<T> = T | T[];
 
 /**
  * Interface for CSS Property Helpers.
  * Must implement toString and declare the `type`` they handle ('color', 'length', etc.)
  */
-type CSSType<T> = {
+export type CSSType<T> = {
   toString(): string;
   type: T;
 }
@@ -18,18 +16,18 @@ type CSSType<T> = {
 /**
  * For general purpose CSS values
  **/
-type CSSValueGeneral = CSSValue<number | string | CSSType<string>>;
+export type CSSValueGeneral = CSSValue<number | string | CSSType<string>>;
 
 /**
  * When you are sure that the value must be a string
  **/
-type CSSValueString = CSSValue<string | CSSType<string>>;
+export type CSSValueString = CSSValue<string | CSSType<string>>;
 
 /**
  * CSS properties that cascade also support these
  * https://drafts.csswg.org/css-cascade/#defaulting-keywords
  */
-type CSSGlobalValues
+export type CSSGlobalValues
   = 'initial'
   | 'inherit'
   | /** combination of `initial` and `inherit` */ 'unset'
@@ -39,42 +37,42 @@ type CSSGlobalValues
  * Absolute size keywords
  * https://drafts.csswg.org/css-fonts-3/#absolute-size-value
  */
-type CSSAbsoluteSize = 'xx-small' | 'x-small' | 'small' | 'medium' | 'large'
+export type CSSAbsoluteSize = 'xx-small' | 'x-small' | 'small' | 'medium' | 'large'
   | 'x-large' | 'xx-large' | CSSType<'absolute-size'>;
 
 /**
  * an angle; 0' | '0deg' | '0grad' | '0rad' | '0turn' | 'etc.
  * https://drafts.csswg.org/css-values-3/#angles
  */
-type CSSAngle = CSSGlobalValues | string | 0 | CSSType<'angle'>;
+export type CSSAngle = CSSGlobalValues | string | 0 | CSSType<'angle'>;
 
 
 /**
  * initial state of an animation.
  * https://drafts.csswg.org/css-animations/#animation-play-state
  */
-type CSSAnimationPlayState = CSSGlobalValues | string | 'paused' | 'running' | CSSType<'animation-play-state'>;
+export type CSSAnimationPlayState = CSSGlobalValues | string | 'paused' | 'running' | CSSType<'animation-play-state'>;
 
 /**
  * blend mode
  * https://drafts.fxtf.org/compositing-1/#ltblendmodegt
  */
-type CSSBlendMode = 'normal' | 'multiply' | 'screen' | 'overlay' | 'darken' | 'lighten' | 'color-dodge' | 'color-burn'
+export type CSSBlendMode = 'normal' | 'multiply' | 'screen' | 'overlay' | 'darken' | 'lighten' | 'color-dodge' | 'color-burn'
   | 'hard-light' | 'soft-light' | 'difference' | 'exclusion' | 'hue' | 'saturation' | 'color' | 'luminosity' | CSSType<'blend-mode'>;
 
 /**
  * Determines the area within which the background is painted.
  * https://drafts.csswg.org/css-backgrounds/#box
  */
-type CSSBox = CSSGlobalValues | string | 'border-box' | 'padding-box' | 'content-box' | CSSType<'box'>;
+export type CSSBox = CSSGlobalValues | string | 'border-box' | 'padding-box' | 'content-box' | CSSType<'box'>;
 
 /**
  * Color can be a named color, transparent, or a color function
  * https://drafts.csswg.org/css-color-3/#valuea-def-color
  */
-type CSSColor = CSSNamedColor | CSSGlobalValues | string | CSSType<'color'>;
+export type CSSColor = CSSNamedColor | CSSGlobalValues | string | CSSType<'color'>;
 
-type CSSNamedColor =
+export type CSSNamedColor =
   'aliceblue' | 'antiquewhite' | 'aqua' | 'aquamarine' | 'azure' | 'beige' | 'bisque' | 'black' | 'blanchedalmond' | 'blue'
   | 'blueviolet' | 'brown' | 'burlywood' | 'cadetblue' | 'chartreuse' | 'chocolate' | 'coral' | 'cornflowerblue' | 'cornsilk'
   | 'crimson' | 'cyan' | 'darkblue' | 'darkcyan' | 'darkgoldenrod' | 'darkgray' | 'darkgreen' | 'darkgrey' | 'darkkhaki'
@@ -94,45 +92,45 @@ type CSSNamedColor =
  * Special type for border-color which can use 1 or 4 colors
  * https://drafts.csswg.org/css-backgrounds-3/#border-color
  */
-type CSSColorSet = string | CSSColor | CSSType<'color-set'>
+export type CSSColorSet = string | CSSColor | CSSType<'color-set'>
 
 /** For gradients etc */
-type CSSColorStop = [CSSColor, CSSPercentage | CSSLength];
+export type CSSColorStop = [CSSColor, CSSPercentage | CSSLength];
 
 /**
  * Type for align-items and align-self in flex
  */
-type CSSFlexAlign = 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch' | CSSType<'flex-align'>;
+export type CSSFlexAlign = 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch' | CSSType<'flex-align'>;
 
 /**
  * a gradient function like linear-gradient
  * https://drafts.csswg.org/css-images-3/#gradients
  */
-type CSSGradient = CSSGlobalValues | string | CSSType<'gradient'>;
+export type CSSGradient = CSSGlobalValues | string | CSSType<'gradient'>;
 
 /**
  * complex type that describes the size of fonts
  * https://drafts.csswg.org/css-fonts-3/#propdef-font-size
  */
-type CSSFontSize = CSSGlobalValues | CSSLength | CSSPercentage | CSSAbsoluteSize | CSSRelativeSize;
+export type CSSFontSize = CSSGlobalValues | CSSLength | CSSPercentage | CSSAbsoluteSize | CSSRelativeSize;
 
 /**
  * a value that serves as an image
  * https://drafts.csswg.org/css-images-3/#typedef-image
  */
-type CSSImage = CSSGlobalValues | string | CSSGradient | CSSUrl | CSSType<'image'>;
+export type CSSImage = CSSGlobalValues | string | CSSGradient | CSSUrl | CSSType<'image'>;
 
 /**
  * an length; 0 | '0px' | '0em' etc.
  * https://drafts.csswg.org/css-values-3/#lengths
  */
-type CSSLength = CSSGlobalValues | string | number | CSSType<'length'>;
+export type CSSLength = CSSGlobalValues | string | number | CSSType<'length'>;
 
 /**
  * Style of a line (e.g. border-style)
  * https://drafts.csswg.org/css-backgrounds-3/#line-style
  */
-type CSSLineStyle = string | 'none' | 'hidden' | 'dotted'
+export type CSSLineStyle = string | 'none' | 'hidden' | 'dotted'
   | 'dashed' | 'solid' | 'double' | 'groove' | 'ridge' | 'inset'
   | 'outset' | CSSType<'line-style'>;
 
@@ -140,43 +138,43 @@ type CSSLineStyle = string | 'none' | 'hidden' | 'dotted'
  * Special type for border-style which can use 1 or 4 line-style
  * https://drafts.csswg.org/css-backgrounds-3/#border-style
  */
-type CSSLineStyleSet = string | CSSLineStyle | CSSType<'line-style-set'>
+export type CSSLineStyleSet = string | CSSLineStyle | CSSType<'line-style-set'>
 
 /**
  * Overlow modes
  * https://drafts.csswg.org/css-overflow-3/#propdef-overflow
  */
-type CSSOverflow = 'visible' | 'hidden' | 'scroll' | 'clip' | 'auto';
+export type CSSOverflow = 'visible' | 'hidden' | 'scroll' | 'clip' | 'auto';
 
 /**
  * a percentage; 0 | '0%' etc.
  * https://drafts.csswg.org/css-values-3/#percentage
  */
-type CSSPercentage = CSSGlobalValues | string | 0 | CSSType<'percentage'>;
+export type CSSPercentage = CSSGlobalValues | string | 0 | CSSType<'percentage'>;
 
 /**
  * Defines a position (e.g. background-position)
  * https://drafts.csswg.org/css-backgrounds-3/#position
  */
-type CSSPosition = CSSAngle | string | CSSType<'position'>;
+export type CSSPosition = CSSAngle | string | CSSType<'position'>;
 
 /**
  * Relative size keywords
  * https://drafts.csswg.org/css-fonts-3/#relative-size-value
  */
-type CSSRelativeSize = 'larger' | 'smaller' | CSSType<'relative-size'>;
+export type CSSRelativeSize = 'larger' | 'smaller' | CSSType<'relative-size'>;
 
 /**
  * Specifies how background images are tiled after they have been sized and positioned
  * https://drafts.csswg.org/css-backgrounds/#repeat-style
  */
-type CSSRepeatStyle = string | 'repeat-x' | 'repeat-y' | 'repeat' | 'space' | 'round' | 'no-repeat' | CSSType<'repeat-style'>;
+export type CSSRepeatStyle = string | 'repeat-x' | 'repeat-y' | 'repeat' | 'space' | 'round' | 'no-repeat' | CSSType<'repeat-style'>;
 
 /**
  * Starting position for many gradients
  * https://drafts.csswg.org/css-images-3/#typedef-side-or-corner
  */
-type CSSSideOrCorner = CSSAngle
+export type CSSSideOrCorner = CSSAngle
   | 'left' | 'right' | 'top' | 'bottom'
   | 'to left' | 'to right' | 'to top' | 'to bottom'
   | 'left top' | 'right top' | 'left bottom' | 'right bottom'
@@ -186,7 +184,7 @@ type CSSSideOrCorner = CSSAngle
   | CSSType<'side-or-corner'>;
 
 /** Supporting by `-timing-function` properties */
-type CSSTimingFunction
+export type CSSTimingFunction
   = /** e.g. steps(int,start|end)|cubic-bezier(n,n,n,n) */ string
   | CSSGlobalValues
   | 'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | 'linear' | 'step-start' | 'step-end' | CSSType<'timing-function'>;
@@ -195,12 +193,12 @@ type CSSTimingFunction
  * Expressed as url('protocol://')
  * https://drafts.csswg.org/css-values-3/#urls
  */
-type CSSUrl = string | CSSType<'url'>;
+export type CSSUrl = string | CSSType<'url'>;
 
 /**
  * This interface documents key CSS properties for autocomplete
  */
-interface CSSProperties {
+export interface CSSProperties {
   /** Smooth scrolling on an iPhone */
   '-webkit-overflow-scrolling'?: string;
 
@@ -1645,11 +1643,11 @@ interface CSSProperties {
   zoom?: "auto" | number;
 }
 
-interface NestedCSSProperties extends CSSProperties {
+export interface NestedCSSProperties extends CSSProperties {
   nested?: NestedCSSSelectors;
 }
 
-type FontFace = {
+export type FontFace = {
   fontFamily?: string;
   src?: string;
   unicodeRange?: any;
@@ -1659,14 +1657,14 @@ type FontFace = {
   fontSize?: 'normal' | 'italic' | 'oblique' | CSSGlobalValues;
 }
 
-type MediaQuery = {
+export type MediaQuery = {
   type?: 'screen' | 'print' | 'all';
   orientation?: 'landscape' | 'portrait';
   minWidth?: number;
   maxWidth?: number;
 }
 
-type NestedCSSSelectors = {
+export type NestedCSSSelectors = {
   /** State selector */
   '&:active'?: CSSProperties;
   '&:any'?: CSSProperties;
@@ -1723,7 +1721,7 @@ type NestedCSSSelectors = {
 /**
  * For animation keyframe definition
  */
-interface KeyFrames {
+export interface KeyFrames {
   [
   /** stuff like `from`, `to` or `10%` etc*/
   key: string


### PR DESCRIPTION
This PR aims to solve this issue #40 .  If accepted, it should be considered a minor/major change since it breaks nesting selectors next to properties.

It adds the following "nested" property to allow nesting selectors:
```ts
style({
  nested: {
    '@media screen': {
        color: 'red'
     }
  }
})
```

It adds shorthands for simple pseudo-selectors so they can still be used without going into a "nested" property.

```ts
style({
    color: 'blue',
    '&:active': {
      color: 'red' 
    }
});
```

And adds several CSS Properties needed to compile and pass the existing tests

* [ ] Check that `nested` actually type checks https://github.com/Microsoft/TypeScript/issues/12584