### PR TITLE
export type CSSProperties

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -240,3 +240,8 @@ export const media = (mediaQuery: MediaQuery, ...objects: NestedCSSProperties[])
   const object = { [stringMediaQuery]: extend(...objects) };
   return object;
 }
+
+/**
+ * Allows the use of importing the CSSProperties interface 
+ */
+export type CSSProps = CSSProperties


### PR DESCRIPTION
In my project I would really like to use the `CSSProperties` interface like so:
```
import { CSSProperties } from 'typestyle'
```