### PR TITLE
disconnect extend for cleanup up for freestyle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ function cleanUpObjForFreeStyle(object: types.NestedCSSProperties): any {
     }
     else {
       // And we already have something for this key
-      result[key] = ensureString(object[key] as any);
+      result[key] = ensureString((object as any)[key] as any);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,33 @@ export function ensureStringObj(object: any): types.CSSProperties {
   return result;
 }
 
+/**
+ * We need to do the following to *our* objects before passing to freestyle:
+ * - Convert any CSSType to their string value
+ * - For any `$nest` directive move up to FreeStyle style nesting
+ * - For any `$unique` directive map to FreeStyle Unique
+ */
+function cleanUpObjForFreeStyle(object: types.NestedCSSProperties): any {
+  /** The final result we will return */
+  const result: types.CSSProperties & Dictionary = {};
+
+  for (const key in object) {
+    if (key === '$nest') {
+      const nested = object.$nest!;
+      for (let selector in nested) {
+        const subproperties = nested[selector]!;
+        result[selector] = cleanUpObjForFreeStyle(ensureStringObj(subproperties));
+      }
+    }
+    else {
+      // And we already have something for this key
+      result[key] = ensureString(object[key] as any);
+    }
+  }
+
+  return result;
+}
+
 
 /**
  * We have a single stylesheet that we update as components register themselves
@@ -151,7 +178,7 @@ export const css = () => raw ? raw + freeStyle.getStyles() : freeStyle.getStyles
  * Takes CSSProperties and return a generated className you can use on your component
  */
 export function style(...objects: types.NestedCSSProperties[]) {
-  const object = extend(...objects);
+  const object = cleanUpObjForFreeStyle(extend(...objects));
   const className = freeStyle.registerStyle(object);
   styleUpdated();
   return className;
@@ -169,7 +196,7 @@ export function fontFace(...fontFace: types.FontFace[]): void {
  * Takes CSSProperties and registers it to a global selector (body, html, etc.)
  */
 export function cssRule(selector: string, ...objects: types.NestedCSSProperties[]): void {
-  const object = extend(...objects);
+  const object = cleanUpObjForFreeStyle(extend(...objects));
   freeStyle.registerRule(selector, object);
   styleUpdated();
   return;
@@ -217,25 +244,20 @@ export function extend(...objects: types.NestedCSSProperties[]): types.NestedCSS
         continue;
       }
 
-      // if freestyle media or pseudo selector
-      if ((key.indexOf('&') !== -1 || key.indexOf('@media') === 0)) {
-        result[key] = result[key] ? extend(result[key] as any, val) : ensureStringObj(val);
+      /** if nested media or pseudo selector */
+      if (key === '$nest' && val) {
+        result[key] = result['$nest'] ? extend(result['$nest'], val) : val;
       }
-
-      // if nested media or pseudo selector
-      else if (key === '$nest' && val) {
-        const nested = object.$nest!;
-        for (let selector in nested) {
-          const subproperties = nested[selector]!;
-          result[selector] = result[selector] ? extend(result[selector], subproperties) : ensureStringObj(subproperties);
-        }
+      /** if freestyle sub key that needs merging. We come here due to our recursive calls */
+      else if ((key.indexOf('&') !== -1 || key.indexOf('@media') === 0)) {
+        result[key] = result[key] ? extend(result[key], val) : val;
       }
       else {
-        // And we already have something for this key
-        result[key] = ensureString(val);
+        result[key] = val;
       }
     }
   }
+
   return result;
 }
 

--- a/src/tests/extend.ts
+++ b/src/tests/extend.ts
@@ -6,7 +6,7 @@ describe("extend", () => {
     assert.deepEqual(extend({ color: 'red' }), { color: 'red' });
   });
 
-  it("nested objects should get flattened", () => {
+  it("nested objects should not get flattened", () => {
     assert.deepEqual(
       extend(
         {
@@ -14,13 +14,12 @@ describe("extend", () => {
         },
       ),
       {
-        '&:hover': {
-          color: 'red'
-        }
-      });
+        $nest: { '&:hover': { color: 'red' } }
+      }
+    );
   });
 
-  it("nested objects should get flattened and merge", () => {
+  it("nested objects should merge into non nested", () => {
     assert.deepEqual(
       extend(
         { color: 'grey' },
@@ -28,13 +27,11 @@ describe("extend", () => {
       ),
       {
         color: 'grey',
-        '&:hover': {
-          color: 'red'
-        }
+        $nest: { '&:hover': { color: 'red' } }
       });
   });
 
-  it("nested objects should merge", () => {
+  it("nested objects should merge together", () => {
     assert.deepEqual(
       extend(
         { color: 'grey' },
@@ -45,9 +42,11 @@ describe("extend", () => {
       {
         color: 'grey',
         backgroundColor: 'grey',
-        '&:hover': {
-          color: 'red',
-          backgroundColor: 'red'
+        $nest: {
+          '&:hover': {
+            color: 'red',
+            backgroundColor: 'red'
+          }
         }
       });
   });
@@ -59,9 +58,11 @@ describe("extend", () => {
         { $nest: { '&:hover': { backgroundColor: 'red' } } },
       ),
       {
-        '&:hover': {
-          color: 'red',
-          backgroundColor: 'red'
+        $nest: {
+          '&:hover': {
+            color: 'red',
+            backgroundColor: 'red'
+          }
         }
       });
   });
@@ -73,9 +74,11 @@ describe("extend", () => {
         extend({ $nest: { '&:hover': { backgroundColor: 'red' } } }),
       ),
       {
-        '&:hover': {
-          color: 'red',
-          backgroundColor: 'red'
+        $nest: {
+          '&:hover': {
+            color: 'red',
+            backgroundColor: 'red'
+          }
         }
       });
   });
@@ -89,14 +92,16 @@ describe("extend", () => {
         { $nest: { '&:hover': { fontSize: '14px' }, '&:focus': { fontFamily: 'arial' } } },
       ),
       {
-        '&:hover': {
-          fontSize: '14px',
-          color: 'red',
-          backgroundColor: 'red'
-        },
-        '&:focus': {
-          fontFamily: 'arial',
-          backgroundColor: 'red'
+        $nest: {
+          '&:hover': {
+            fontSize: '14px',
+            color: 'red',
+            backgroundColor: 'red'
+          },
+          '&:focus': {
+            fontFamily: 'arial',
+            backgroundColor: 'red'
+          }
         }
       });
   });


### PR DESCRIPTION
The current `extend` implementation did too much and it was unclear what the returned object might be from extend. 

This could result in surprises for users where extending a *single* object *would still change the object* (e.g. remove `$nest`). 

This PR seperates `extend` from any cleanups needed for free-style object structure.

After this PR I will think through cleaning up other `ensure` functions to have the suffix `ForFreeStyle` so we know why we are doing it :rose: 