### PR TITLE
implement TYPESTYLE_ENV==debug option

### DIFF
--- a/src/internal/debugMode.ts
+++ b/src/internal/debugMode.ts
@@ -1,0 +1,4 @@
+export function isDebugMode(env: {[key: string]: string}): boolean {
+  return env['NODE_ENV'] !== 'production' ||
+         env['TYPESTYLE_ENV'] === 'debug';
+}

--- a/src/internal/typestyle.ts
+++ b/src/internal/typestyle.ts
@@ -1,6 +1,7 @@
 import { Styles } from 'free-style';
 import { ensureStringObj, explodeKeyframes } from './formatting';
 import { extend, raf } from './utilities';
+import { isDebugMode } from './debugMode';
 
 /**
  * All the CSS types in the 'types' namespace
@@ -27,8 +28,14 @@ export class TypeStyle {
    */
   private _lastFreeStyleChangeId: number;
 
-  constructor({ autoGenerateTag }: { autoGenerateTag: boolean }) {
-    const freeStyle = FreeStyle.create();
+  constructor({
+    autoGenerateTag,
+    debug = isDebugMode(process.env),
+  }: {
+    autoGenerateTag: boolean,
+    debug?: boolean,
+  }) {
+    const freeStyle = FreeStyle.create(undefined, debug);
 
     this._autoGenerateTag = autoGenerateTag;
     this._freeStyle = freeStyle;

--- a/src/tests/debugMode.ts
+++ b/src/tests/debugMode.ts
@@ -1,0 +1,16 @@
+import * as assert from 'assert';
+import { isDebugMode } from '../internal/debugMode';
+
+describe("debug mode", () => {
+  it("should be false if NODE_ENV==production and TYPESTYLE_ENV is undefined", () => {
+    assert(!isDebugMode({
+      NODE_ENV: 'production',
+    }), 'NODE_ENV === production && TYPESTYLE_ENV == undefined, but debug mode.');
+  });
+  it("should be true if NODE_ENV==production and TYPESTYLE_ENV==debug", () => {
+    assert(isDebugMode({
+      NODE_ENV: 'production',
+      TYPESTYLE_ENV: 'debug',
+    }), 'NODE_ENV === production && TYPESTYLE_ENV == debug, butnot debug mode.');
+  });
+});


### PR DESCRIPTION
this PR adds TYPESTYLE_ENV to override NODE_ENV==production.

use case:
 - set NODE_ENV==production for other reasons (e.g. ReactJS perf)
 - but wants $debugName to be in effect for better debugging experience.

usage example:
NODE_ENV=production TYPESTYLE_ENV=debug npm run build