### PR TITLE
Add desktop app compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "jsnext:main": "./lib.es2015/index.js",
   "scripts": {
     "build": "tsc -p . && tsc -p tsconfig.es2015.json && webpack && webpack --minimize",
-    "unittest": "mocha -r jsdom-global/register ./lib/tests/**/*.js",
+    "unittest": "mocha ./lib/tests/**/*.js",
     "test": "npm run build && npm run unittest",
     "preversion": "npm run build",
     "postversion": "git push --follow-tags && npm publish",
@@ -32,8 +32,6 @@
     "@types/mocha": "^2.2.39",
     "@types/node": "^7.0.5",
     "mocha": "^3.2.0",
-    "jsdom": "^9.0.0",
-    "jsdom-global": "^2.1.1",
     "ts-node": "^3.0.0",
     "typescript": "^2.3.0-dev.20170217",
     "webpack": "1.14.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "jsnext:main": "./lib.es2015/index.js",
   "scripts": {
     "build": "tsc -p . && tsc -p tsconfig.es2015.json && webpack && webpack --minimize",
-    "unittest": "mocha ./lib/tests/**/*.js",
+    "unittest": "mocha -r jsdom-global/register ./lib/tests/**/*.js",
     "test": "npm run build && npm run unittest",
     "preversion": "npm run build",
     "postversion": "git push --follow-tags && npm publish",
@@ -32,6 +32,8 @@
     "@types/mocha": "^2.2.39",
     "@types/node": "^7.0.5",
     "mocha": "^3.2.0",
+    "jsdom": "^9.0.0",
+    "jsdom-global": "^2.1.1",
     "ts-node": "^3.0.0",
     "typescript": "^2.3.0-dev.20170217",
     "webpack": "1.14.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export const style = ts.style;
  * Assign base window object to given window element. This is useful for desktop apps
  * where window is not global.
  */
-export const setWindow = ts.setWindow;
+export const setGlobal = ts.setGlobal;
 
 /**
  * Creates a new instance of TypeStyle separate from the default instance.

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,12 @@ export const reinit = ts.reinit;
 export const style = ts.style;
 
 /**
+ * Assign base window object to given window element. This is useful for desktop apps
+ * where window is not global.
+ */
+export const setWindow = ts.setWindow;
+
+/**
  * Creates a new instance of TypeStyle separate from the default instance.
  *
  * - Use this for creating a different typestyle instance for a shadow dom component.

--- a/src/internal/typestyle.ts
+++ b/src/internal/typestyle.ts
@@ -31,7 +31,7 @@ export class TypeStyle {
   private _pendingRawChange: boolean;
   private _raw: string;
   private _tag?: StylesTarget;
-  private _window: Window = window;
+  private _window: Window | undefined = typeof window === 'undefined' ? undefined : window;
 
   /**
    * We have a single stylesheet that we update as components register themselves
@@ -104,7 +104,7 @@ export class TypeStyle {
    * Assign base window object to given window element. This is useful for desktop apps
    * where window is not global.
    */
-  public setWindow = (win: Window): void => {
+  public setGlobal = (win: Window): void => {
     this._window = win;
     this.forceRenderStyles();
   }

--- a/src/internal/typestyle.ts
+++ b/src/internal/typestyle.ts
@@ -31,6 +31,7 @@ export class TypeStyle {
   private _pendingRawChange: boolean;
   private _raw: string;
   private _tag?: StylesTarget;
+  private _window: Window = window;
 
   /**
    * We have a single stylesheet that we update as components register themselves
@@ -55,7 +56,7 @@ export class TypeStyle {
   private _afterAllSync(cb: () => void): void {
     this._pending++;
     const pending = this._pending;
-    raf(() => {
+    raf(this._window)(() => {
       if (pending !== this._pending) {
         return;
       }
@@ -68,12 +69,13 @@ export class TypeStyle {
       return this._tag;
     }
 
+    const win = this._window;
     if (this._autoGenerateTag) {
-      const tag = typeof window === 'undefined'
+      const tag = typeof win === 'undefined'
         ? { textContent: '' }
-        : document.createElement('style');
+        : win.document.createElement('style');
 
-      if (typeof document !== 'undefined') {
+      if (typeof win !== 'undefined' && typeof win.document !== 'undefined') {
         document.head.appendChild(tag as any);
       }
       this._tag = tag;
@@ -96,6 +98,15 @@ export class TypeStyle {
     this._pendingRawChange = false;
 
     this._afterAllSync(() => this.forceRenderStyles());
+  }
+
+  /**
+   * Assign base window object to given window element. This is useful for desktop apps
+   * where window is not global.
+   */
+  public setWindow = (win: Window): void  => {
+    this._window = win;
+    this.forceRenderStyles();
   }
 
   /**

--- a/src/internal/typestyle.ts
+++ b/src/internal/typestyle.ts
@@ -76,7 +76,7 @@ export class TypeStyle {
         : win.document.createElement('style');
 
       if (typeof win !== 'undefined' && typeof win.document !== 'undefined') {
-        document.head.appendChild(tag as any);
+        win.document.head.appendChild(tag as any);
       }
       this._tag = tag;
       return tag;
@@ -104,7 +104,7 @@ export class TypeStyle {
    * Assign base window object to given window element. This is useful for desktop apps
    * where window is not global.
    */
-  public setWindow = (win: Window): void  => {
+  public setWindow = (win: Window): void => {
     this._window = win;
     this.forceRenderStyles();
   }

--- a/src/internal/utilities.ts
+++ b/src/internal/utilities.ts
@@ -2,7 +2,7 @@ import * as types from '../types';
 import { Dictionary } from './formatting';
 
 /** Raf for node + browser */
-export const raf = (win: Window = window) => typeof requestAnimationFrame === 'undefined' ? setTimeout : requestAnimationFrame.bind(win);
+export const raf = (win: Window | undefined) => typeof requestAnimationFrame === 'undefined' ? setTimeout : requestAnimationFrame.bind(win);
 
 /**
  * Utility to join classes conditionally

--- a/src/internal/utilities.ts
+++ b/src/internal/utilities.ts
@@ -2,7 +2,7 @@ import * as types from '../types';
 import { Dictionary } from './formatting';
 
 /** Raf for node + browser */
-export const raf = (win = window) => typeof requestAnimationFrame === 'undefined' ? setTimeout : requestAnimationFrame.bind(win);
+export const raf = (win: Window = window) => typeof requestAnimationFrame === 'undefined' ? setTimeout : requestAnimationFrame.bind(win);
 
 /**
  * Utility to join classes conditionally

--- a/src/internal/utilities.ts
+++ b/src/internal/utilities.ts
@@ -2,7 +2,7 @@ import * as types from '../types';
 import { Dictionary } from './formatting';
 
 /** Raf for node + browser */
-export const raf = typeof requestAnimationFrame === 'undefined' ? setTimeout : requestAnimationFrame.bind(window);
+export const raf = (win = window) => typeof requestAnimationFrame === 'undefined' ? setTimeout : requestAnimationFrame.bind(win);
 
 /**
  * Utility to join classes conditionally


### PR DESCRIPTION
This PR aims at enabling typestyle to target specific `Window` object by exposing a `setWindow` method.
Use cases include Electron/NodeWebkit apps.

When setting up the app in the main screen when you have the window, you would just need to require `setWindow` from typestyle and call it with `window`.

I added a `forceRenderStyles` at the end to re-render if it was already fired.


Disclaimer: I need this in my project, so I've published a fork (typestyle-nw) which I'll delete when this PR is merged. In the meantime, I'm happy to iterate on this if you spot anything