### PR TITLE
Export TypeStyle class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { TypeStyle } from './internal/typestyle';
+export { TypeStyle };
 
 /**
  * All the CSS types in the 'types' namespace


### PR DESCRIPTION
Currently TypeStyle class is private, but all the methods of the default instance of it are exported, and also createTypeStyle is exported.  This just exports the result type of createTypeStyle.