### PR TITLE
added function that returns style object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,12 @@ export const reinit = ts.reinit;
  */
 export const style = ts.style;
 
+
+/**
+ * Return a parsed style object generated based on the style properties that where provided, without adding the object to the sheet
+ */
+export const getStyleObject = ts.getStyleObject;
+
 /**
  * Creates a new instance of TypeStyle separate from the default instance.
  *

--- a/src/internal/typestyle.ts
+++ b/src/internal/typestyle.ts
@@ -207,4 +207,11 @@ export class TypeStyle {
     this._styleUpdated();
     return className;
   }
+
+  public getStyleObject = (...objects: (types.NestedCSSProperties | undefined | null | false)[]): any => {
+    const css = ensureStringObj(extend(...objects));
+    return css.result;
+  }
+
+
 }

--- a/src/tests/basic.tsx
+++ b/src/tests/basic.tsx
@@ -1,4 +1,4 @@
-import { style, getStyles, reinit, classes, cssRule, createTypeStyle } from '../index';
+import { style, getStyles, reinit, classes, cssRule, createTypeStyle, getStyleObject } from '../index';
 import * as assert from 'assert';
 
 describe("initial test", () => {
@@ -65,6 +65,14 @@ describe("initial test", () => {
     style({ color: 'transparent' });
     assert.equal(getStyles(), '.transparent,.fwarpl0{color:transparent}');
   });
+
+  it("should return a style object", () => {
+    reinit();
+    var result = getStyleObject({
+      color: 'blue'
+    });
+    assert.equal( result.color,  'blue' );
+  } );
 
   it("should support dedupe by default", () => {
     reinit();


### PR DESCRIPTION
I was looking for a way to just inject the style directly into my DOM elements in Angular 4.
Since the ngStyle directive accepts a style object, I added a function to Typestyle that will parse the style and return the object without adding it to the global stylesheet.
I can then use my ngStyle binding to inject the css inline.