### PR TITLE
Fix media typings (result is NestedCSSProperties)

### DIFF
--- a/src/internal/utilities.ts
+++ b/src/internal/utilities.ts
@@ -67,11 +67,11 @@ export const media = (mediaQuery: types.MediaQuery, ...objects: types.NestedCSSP
 
   const stringMediaQuery = `@media ${mediaQuerySections.join(' and ')}`;
 
-  const object  = {
+  const object: types.NestedCSSProperties  = {
     $nest: {
       [stringMediaQuery]: extend(...objects)
     }
-  } as types.CSSProperties;
+  };
   return object;
 }
 


### PR DESCRIPTION
This is more corerct result typing for `media` helper and aslo would allow using `media` helper in nested styles:

```ts
$nested: {
  ...media({maxWidth: '500px'}, {...}).$nested
}
```