### PR TITLE
Fix `raf` For IE9

### DIFF
--- a/src/internal/utilities.ts
+++ b/src/internal/utilities.ts
@@ -2,7 +2,7 @@ import * as types from '../types';
 import { Dictionary } from './formatting';
 
 /** Raf for node + browser */
-export const raf = typeof requestAnimationFrame === 'undefined' ? function(cb: Function) {setTimeout(cb, 0)} : requestAnimationFrame.bind(window);
+export const raf = typeof requestAnimationFrame === 'undefined' ? (cb: () => void) => setTimeout(cb, 0) : requestAnimationFrame.bind(window);
 
 /**
  * Utility to join classes conditionally

--- a/src/internal/utilities.ts
+++ b/src/internal/utilities.ts
@@ -2,7 +2,7 @@ import * as types from '../types';
 import { Dictionary } from './formatting';
 
 /** Raf for node + browser */
-export const raf = typeof requestAnimationFrame === 'undefined' ? setTimeout : requestAnimationFrame.bind(window);
+export const raf = typeof requestAnimationFrame === 'undefined' ? function(cb: Function) {setTimeout(cb, 0)} : requestAnimationFrame.bind(window);
 
 /**
  * Utility to join classes conditionally


### PR DESCRIPTION
TypeStype unable to run on IE9.

![image](https://user-images.githubusercontent.com/437917/31760680-737b558c-b4f0-11e7-9b85-e24bf82ce820.png)

Calling `setTimeout` without second parameter cause the problem.

Please, merge IE9 fix and publish to npm.
