### PR TITLE
Add a function to override disabling of $debugName.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,18 @@ export const reinit = ts.reinit;
 export const style = ts.style;
 
 /**
+ * Overrides stripping of $debugName when process.env.NODE_ENV is not available (like in the browser).
+ * If a value is passed, then it will become the new value.
+ */
+let _debugNameDisabled: boolean = false;
+export function debugNameDisabled(newValue?: boolean): boolean{
+  if (typeof newValue !== 'undefined')
+    _debugNameDisabled = newValue;
+
+  return _debugNameDisabled;
+}
+
+/**
  * Creates a new instance of TypeStyle separate from the default instance.
  *
  * - Use this for creating a different typestyle instance for a shadow dom component.

--- a/src/internal/formatting.ts
+++ b/src/internal/formatting.ts
@@ -1,4 +1,5 @@
-import * as types from './../types';
+import * as types from '../types';
+import {debugNameDisabled} from '../index';
 import * as FreeStyle from 'free-style';
 
 export type Dictionary = { [key: string]: any; };
@@ -31,7 +32,7 @@ export function ensureStringObj(object: types.NestedCSSProperties): { result: an
       }
     }
     else if (key === '$debugName') {
-      debugName = val;
+      debugName = debugNameDisabled() ? '' : val;
     }
     else {
       result[key] = val

--- a/src/tests/basic.tsx
+++ b/src/tests/basic.tsx
@@ -1,4 +1,4 @@
-import { style, getStyles, reinit, classes, cssRule, createTypeStyle } from '../index';
+import { style, getStyles, reinit, classes, cssRule, createTypeStyle, debugNameDisabled } from '../index';
 import * as assert from 'assert';
 
 describe("initial test", () => {
@@ -109,6 +109,8 @@ describe("initial test", () => {
 
   it("should support $debugName", () => {
     reinit();
+    debugNameDisabled(false);
+
     style({
       $debugName: 'sample',
       color: 'blue',
@@ -119,6 +121,22 @@ describe("initial test", () => {
       }
     });
     assert.equal(getStyles(), '.sample_fy3xmhm{color:blue}.sample_fy3xmhm:hover{color:rgba(0, 0, 0, 0)}');
+  });
+
+  it("should support disabling $debugName via function call", () => {
+    reinit();
+    debugNameDisabled(true);
+
+    style({
+      $debugName: 'sample',
+      color: 'blue',
+      $nest: {
+        '&:hover': {
+          color: 'rgba(0, 0, 0, 0)',
+        }
+      }
+    });
+    assert.equal(getStyles(), '.fy3xmhm{color:blue}.fy3xmhm:hover{color:rgba(0, 0, 0, 0)}');
   });
 
   it("style should ignore 'false' 'null' and 'undefined'", () => {


### PR DESCRIPTION
Hi!
I added the `debugNameDisabled` function which can be used to read and set a variable which will disable `$debugName`. This is useful in situations where `process.env.NODE_ENV` is not available (like in the browser).
Enjoy!
  Paolo