### PR TITLE
omit $debugName values in production

### DIFF
--- a/src/internal/typestyle.ts
+++ b/src/internal/typestyle.ts
@@ -17,8 +17,10 @@ export type StylesTarget = { textContent: string | null };
 const createFreeStyle = () => FreeStyle.create(
   /** Use the default hash function */
   undefined,
-  /** Preserve $debugName values */
-  true,
+  /** Preserve $debugName values if NODE_ENV is not available (browser) */
+  typeof process !== 'undefined'
+    ? process.env.NODE_ENV !== 'production'
+    : true
 );
 
 /**

--- a/src/tests/basic.tsx
+++ b/src/tests/basic.tsx
@@ -121,6 +121,23 @@ describe("initial test", () => {
     assert.equal(getStyles(), '.sample_fy3xmhm{color:blue}.sample_fy3xmhm:hover{color:rgba(0, 0, 0, 0)}');
   });
 
+  it("should omit $debugName in production", () => {
+    const NODE_ENV = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    reinit();
+    style({
+      $debugName: 'sample',
+      color: 'blue',
+      $nest: {
+        '&:hover': {
+          color: 'rgba(0, 0, 0, 0)',
+        }
+      }
+    });
+    process.env.NODE_ENV = NODE_ENV;
+    assert.equal(getStyles(), '.fy3xmhm{color:blue}.fy3xmhm:hover{color:rgba(0, 0, 0, 0)}');
+  });
+
   it("style should ignore 'false' 'null' and 'undefined'", () => {
     reinit();
     style(

--- a/src/tests/keyframes.ts
+++ b/src/tests/keyframes.ts
@@ -13,6 +13,20 @@ describe("keyframes", () => {
       assert.equal(animationName, 'fade-in_f1gwuh0p');
   });
 
+  it('should omit $debugName in production', () => {
+      const NODE_ENV = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      reinit();
+      const animationName = keyframes({
+        $debugName: 'fade-in',
+        from: { opacity: 0 },
+        to: { opacity: 1 }
+      });
+      process.env.NODE_ENV = NODE_ENV;
+
+      assert.equal(animationName, 'f1gwuh0p');
+  });
+
   it('supports generated animation name', () => {
     reinit();
     const animationName = keyframes({


### PR DESCRIPTION
Hello!) I think `$debugName` is very helpful when it comes to navigation in HTML tree, but  it is not necessary in production.

In accordance with:

- [#221](https://github.com/typestyle/typestyle/pull/221) (I described my vision here)
- [#217](https://github.com/typestyle/typestyle/pull/217#issuecomment-354699213)
- [#126](https://github.com/typestyle/typestyle/pull/126)

I propose to return the opportunity to control $debugName visibility with a simple fix.

`free-style` library actually [does it](https://github.com/blakeembrey/free-style/pull/54/files), but in `typestyle`[we preserve $debugName visibility](https://github.com/typestyle/typestyle/pull/217#issuecomment-354699213) with hardcoded `true` value.

Because of this some people try to implement env-based solutions (like `debugName` helpers) on top of the existing API creating unnecessary repetitions in code. From my point of view we can avoid such problems. I read carefully [this thread](https://github.com/typestyle/typestyle/pull/126#issuecomment-288083176) and came to conclusion that we could preserve `$debugName` values in case NODE_ENV was unavailable (in browsers) and otherwise relied on NODE_ENV (in NodeJS SSR, webpack, probably rollup, ...). We all know that webpack [is able to embedd](https://webpack.js.org/guides/production/#specify-the-environment) `process.env.NODE_ENV` values in code using `DefinePlugin`. As the result, my production build will have only hashes as class names. To reduce bundle size I can even strip `$debugName`s in production frontend code, using some webpack loader (if I will find it expedient).
