### PR TITLE
feat(utilities): allow object params in classes function

### DIFF
--- a/src/internal/utilities.ts
+++ b/src/internal/utilities.ts
@@ -20,8 +20,12 @@ export const raf: (cb: () => void) => void =
 /**
  * Utility to join classes conditionally
  */
-export function classes(...classes: (string | false | undefined | null)[]): string {
-  return classes.filter(c => !!c).join(' ');
+export function classes(...classes: (string | false | undefined | null | { [className: string]: any })[]): string {
+  return classes
+    .map(c => c && typeof c === 'object' ? Object.keys(c).map(key => !!c[key] && key) : [c])
+    .reduce((flattened, c) => c instanceof Array ? flattened.concat(c) : flattened.concat(c), [] as string[])
+    .filter(c => !!c)
+    .join(' ');
 }
 
 /**

--- a/src/tests/basic.tsx
+++ b/src/tests/basic.tsx
@@ -57,6 +57,7 @@ describe("initial test", () => {
     assert.equal(classes("a", "b"), "a b");
     assert.equal(classes("a", false && "b"), "a");
     assert.equal(classes("a", false && "b", "c"), "a c");
+    assert.equal(classes("a", false && "b", "c", { d: false, e: true }, { f: {}, g: null }), "a c e f");
   });
 
   it("transparent string should render transparent in color property", () => {


### PR DESCRIPTION
This PR adds a feature to allow passing objects to the `classes` function.

```typescript
const classNames = classes('a', { b: true, c: false, d: undefined });

// classNames will equal 'a b';
```

I'm aware you can achieve the same result using

```typescript
const classNames = classes('a', true && 'b', false && 'c', undefined && 'd');
```

But there are times when an object map is more convenient or readable.

This is a nice feature in the excellent [classnames](https://www.npmjs.com/package/classnames) library. Since typestyle has its own classes function it would be nice if it supported this too.