### PR TITLE
Upgrade to free-style@2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1174,9 +1174,9 @@
       }
     },
     "free-style": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/free-style/-/free-style-2.5.1.tgz",
-      "integrity": "sha512-X7dtUSTrlS1KRQBtiQ618NWIRDdRgD91IeajKCSh0fgTqArSixv+n3ea6F/OSvrvg14tPLR+yCq2s+O602+pRw=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/free-style/-/free-style-2.6.1.tgz",
+      "integrity": "sha512-uaVA8e57tvhrFKAl6x32SGIrGFBoeTAFtfHDzWxjPhiXQiUxOI6EEdEReRkjNO2H9XcdMJXXEnMHw8Q7iMYLbw=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1204,7 +1204,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1225,12 +1226,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1245,17 +1248,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1372,7 +1378,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1384,6 +1391,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1398,6 +1406,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1405,12 +1414,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1429,6 +1440,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1509,7 +1521,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1521,6 +1534,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1606,7 +1620,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1642,6 +1657,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1661,6 +1677,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1704,12 +1721,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/typestyle/typestyle#readme",
   "dependencies": {
     "csstype": "^2.4.0",
-    "free-style": "2.5.1"
+    "free-style": "2.6.1"
   },
   "devDependencies": {
     "@types/mocha": "5.1.0",

--- a/src/tests/basic.tsx
+++ b/src/tests/basic.tsx
@@ -157,7 +157,7 @@ describe("initial test", () => {
       strokeWidth: 4,
       strokeMiterlimit: 10,
     });
-    assert.equal(getStyles(), '.fdky2ev{stroke-width:4,stroke-miterlimit:10}');
+    assert.equal(getStyles(), '.f1xs2ny7{stroke-miterlimit:10;stroke-width:4}');
   });
 
   it("should generate unique instances when typestyle() is called", () => {

--- a/src/tests/basic.tsx
+++ b/src/tests/basic.tsx
@@ -151,6 +151,15 @@ describe("initial test", () => {
     assert.equal(getStyles(), '.fb25ljk{background-color:red;color:blue}');
   });
 
+  it("style should not append px to numeric properties", () => {
+    reinit();
+    style({
+      strokeWidth: 4,
+      strokeMiterlimit: 10,
+    });
+    assert.equal(getStyles(), '.fdky2ev{stroke-width:4,stroke-miterlimit:10}');
+  });
+
   it("should generate unique instances when typestyle() is called", () => {
     const ts1 = createTypeStyle({ textContent: '' });
     const ts2 = createTypeStyle({ textContent: '' });


### PR DESCRIPTION
While this is a duplication of a greenkeeper PR, I thought I would raise this separately rather than comment on the existing greenkeeper one.  Primarily, as I've included what an additional test in this PR to illustrate *why* I'd like to see `typestyle` upgrade to `free-style@2.6.x`.

Have been doing a lot with SVG lately, and recently wanted to customise `stroke-miterlimit`.  This has only recently become whitelisted as a numeric property in `free-style` and thus on the `2.5.1` version still get's a pesky `px` appended to the generated CSS output.  Validated this with the initial breaking test, and then validated the fix with the upgrade to `free-style@2.6.1`.

Thanks for all the work on `typestyle` - definitely my goto for CSS styling these days.