### PR TITLE
Fixes "Go to Definition" on stylesheet function classes

### DIFF
--- a/src/internal/typestyle.ts
+++ b/src/internal/typestyle.ts
@@ -207,13 +207,13 @@ export class TypeStyle {
    * returns an object where property names are the same ideal class names and the property values are
    * the actual generated class names using the ideal class name as the $debugName
    */
-  public stylesheet = <Names extends string = any>(classes: types.CSSClasses<Names>): types.CSSClassNames<Names> => {
-    const classNames = Object.getOwnPropertyNames(classes) as (Names)[];
-    const result = {} as types.CSSClassNames<Names>;
+  public stylesheet = <Classes extends types.CSSClasses<string>>(classes: Classes): { [ClassName in keyof Classes]: string} => {
+    const classNames = Object.getOwnPropertyNames(classes) as (keyof Classes)[];
+    const result = {} as { [ClassName in keyof Classes]: string};
     for (let className of classNames) {
       const classDef = classes[className] as types.NestedCSSProperties
       if (classDef) {
-        classDef.$debugName = className
+        classDef.$debugName = className as string
         result[className] = this.style(classDef);
       }
     }


### PR DESCRIPTION
Previously if you were to execute "Go to Definition" on the symbol `hi` in the below example the following message would appear: "No definition found for 'hi'". This PR adjust the types of the `stylesheet` function so TypeScript can successfully resolve that "Go to Definition" action.

```
const css = stylesheet({
  hi: {
    color: "blue"
  }
});

css.hi;
    ^ "Go to Definition" here was failing
```