### PR TITLE
doc: rework stylesheet typing to improve typescript inference

### DIFF
--- a/src/internal/typestyle.ts
+++ b/src/internal/typestyle.ts
@@ -207,9 +207,9 @@ export class TypeStyle {
    * returns an object where property names are the same ideal class names and the property values are
    * the actual generated class names using the ideal class name as the $debugName
    */
-  public stylesheet = <Classes extends types.CSSClasses<string>>(classes: Classes): { [ClassName in keyof Classes]: string} => {
-    const classNames = Object.getOwnPropertyNames(classes) as (keyof Classes)[];
-    const result = {} as { [ClassName in keyof Classes]: string};
+  public stylesheet = <Classes extends string>(classes: types.CSSClasses<Classes>): { [ClassName in Classes]: string} => {
+    const classNames = Object.getOwnPropertyNames(classes) as Classes[];
+    const result = {} as { [ClassName in Classes]: string};
     for (let className of classNames) {
       const classDef = classes[className] as types.NestedCSSProperties
       if (classDef) {


### PR DESCRIPTION
This improves the navigate to definition and such of an object in a stylesheet.

Screenshots from vscode

Without this change:

![Screen Shot 2020-10-27 at 8 07 55 PM](https://user-images.githubusercontent.com/760204/97386089-52e48f80-1890-11eb-9f30-dfe480116995.png)

With this change:

![Screen Shot 2020-10-27 at 8 07 35 PM](https://user-images.githubusercontent.com/760204/97386135-6f80c780-1890-11eb-8312-a64f39dfb879.png)

I'm not sure if this works in older typescript versions, i only tested on 4.0.3.