### PR TITLE
Adding support for the "prefers color scheme" media query

### DIFF
--- a/src/internal/utilities.ts
+++ b/src/internal/utilities.ts
@@ -80,6 +80,7 @@ export const media = (mediaQuery: MediaQuery, ...objects: (NestedCSSProperties |
   if (mediaQuery.maxWidth) mediaQuerySections.push(`(max-width: ${mediaLength(mediaQuery.maxWidth)})`);
   if (mediaQuery.minHeight) mediaQuerySections.push(`(min-height: ${mediaLength(mediaQuery.minHeight)})`);
   if (mediaQuery.maxHeight) mediaQuerySections.push(`(max-height: ${mediaLength(mediaQuery.maxHeight)})`);
+  if (mediaQuery.prefersColorScheme) mediaQuerySections.push(`(prefers-color-scheme: ${mediaQuery.prefersColorScheme})`);
 
   const stringMediaQuery = `@media ${mediaQuerySections.join(' and ')}`;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export type MediaQuery = {
   maxWidth?: number | string;
   minHeight?: number | string;
   maxHeight?: number | string;
+  prefersColorScheme?: "dark" | "light";
 }
 
 export type NestedCSSSelectors = {


### PR DESCRIPTION
Hello! I'd like to add support for the "prefers-color-scheme" CSS media feature. This is used to detect if the user has requested a light or dark color theme and fits perfectly in the media utility function. [[1]](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)